### PR TITLE
fix: deployment scripts when using other output formats in profile configuration

### DIFF
--- a/deployment/cognito.sh
+++ b/deployment/cognito.sh
@@ -1,11 +1,11 @@
 # Copyright 2023 Amazon Web Services, Inc
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,10 +18,10 @@
 
 export AWS_PROFILE=$TEAM_ACCOUNT_PROFILE
 
-cognitoUserpoolId=`aws cognito-idp list-user-pools --max-results 10 | jq -r '.UserPools[] | select(.Name | contains("team06dbb7fc")) | .Id'`
-clientID=`aws cognito-idp list-user-pool-clients --user-pool-id $cognitoUserpoolId | jq -r '.UserPoolClients[] | select(.ClientName | contains("clientWeb")) | .ClientId'`
-applicationURL=`aws amplify list-apps | jq -r '.apps[] | select(.name=="TEAM-IDC-APP") | .defaultDomain' `
-appURL=`aws cognito-idp describe-user-pool-client --user-pool-id $cognitoUserpoolId --client-id $clientID | jq -r '.UserPoolClient | .CallbackURLs[]'`
+cognitoUserpoolId=`aws cognito-idp list-user-pools --max-results 10 --output json | jq -r '.UserPools[] | select(.Name | contains("team06dbb7fc")) | .Id'`
+clientID=`aws cognito-idp list-user-pool-clients --user-pool-id $cognitoUserpoolId --output json | jq -r '.UserPoolClients[] | select(.ClientName | contains("clientWeb")) | .ClientId'`
+applicationURL=`aws amplify list-apps --output json | jq -r '.apps[] | select(.name=="TEAM-IDC-APP") | .defaultDomain' `
+appURL=`aws cognito-idp describe-user-pool-client --user-pool-id $cognitoUserpoolId --client-id $clientID --output json | jq -r '.UserPoolClient | .CallbackURLs[]'`
 callbackUrl="$appURL"
 
 aws cognito-idp create-identity-provider --user-pool-id $cognitoUserpoolId --provider-name=IDC --provider-type SAML --provider-details file://details.json --attribute-mapping email=Email --idp-identifiers team

--- a/deployment/destroy.sh
+++ b/deployment/destroy.sh
@@ -1,11 +1,11 @@
 # Copyright 2023 Amazon Web Services, Inc
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,8 +17,8 @@
 
 export AWS_PROFILE=$TEAM_ACCOUNT_PROFILE
 
-appId=`aws amplify list-apps | jq -r '.apps[] | select(.name=="TEAM-IDC-APP") | .appId' `
-stackName=`aws amplify get-backend-environment --app-id $appId --environment-name main | jq -r '.backendEnvironment | .stackName'`
+appId=`aws amplify list-apps --output json | jq -r '.apps[] | select(.name=="TEAM-IDC-APP") | .appId' `
+stackName=`aws amplify get-backend-environment --app-id $appId --environment-name main --output json | jq -r '.backendEnvironment | .stackName'`
 
 aws cloudformation delete-stack --stack-name $stackName
 

--- a/deployment/init.sh
+++ b/deployment/init.sh
@@ -1,11 +1,11 @@
 # Copyright 2022 Amazon Web Services, Inc
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,9 +21,9 @@
 
 export AWS_PROFILE=$ORG_MASTER_PROFILE
 
-idc=`aws organizations list-delegated-administrators --service-principal sso.amazonaws.com | jq -r '.DelegatedAdministrators[] | select(.Id=='\"$TEAM_ACCOUNT\"') | .Id'`
-cloudtrail=`aws organizations list-delegated-administrators --service-principal cloudtrail.amazonaws.com | jq -r '.DelegatedAdministrators[] | select(.Id=='\"$TEAM_ACCOUNT\"') | .Id'`
-accountManager=`aws organizations list-delegated-administrators --service-principal account.amazonaws.com | jq -r '.DelegatedAdministrators[] | select(.Id=='\"$TEAM_ACCOUNT\"') | .Id'`
+idc=`aws organizations list-delegated-administrators --service-principal sso.amazonaws.com --output json | jq -r '.DelegatedAdministrators[] | select(.Id=='\"$TEAM_ACCOUNT\"') | .Id'`
+cloudtrail=`aws organizations list-delegated-administrators --service-principal cloudtrail.amazonaws.com --output json | jq -r '.DelegatedAdministrators[] | select(.Id=='\"$TEAM_ACCOUNT\"') | .Id'`
+accountManager=`aws organizations list-delegated-administrators --service-principal account.amazonaws.com --output json | jq -r '.DelegatedAdministrators[] | select(.Id=='\"$TEAM_ACCOUNT\"') | .Id'`
 
 # Enable trusted access for account management
 aws organizations enable-aws-service-access --service-principal account.amazonaws.com

--- a/deployment/integration.sh
+++ b/deployment/integration.sh
@@ -1,12 +1,12 @@
 # Copyright 2022 Amazon Web Services, Inc
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License ateiifccuguhukbglvivtflddnheicjudncrlcdhjtlucr
 
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,10 +21,10 @@ export AWS_PROFILE=$TEAM_ACCOUNT_PROFILE
 
 green='\033[0;32m'
 clear='\033[0m'
-cognitoUserpoolId=`aws cognito-idp list-user-pools --max-results 10 | jq -r '.UserPools[] | select(.Name | contains("team06dbb7fc")) | .Id'`
+cognitoUserpoolId=`aws cognito-idp list-user-pools --max-results 10 --output json | jq -r '.UserPools[] | select(.Name | contains("team06dbb7fc")) | .Id'`
 cognitouserpoolhostedUIdomain=`aws cognito-idp describe-user-pool --user-pool-id $cognitoUserpoolId  |jq -r '.UserPool.Domain'`
-applicationURL=`aws amplify list-apps | jq -r '.apps[] | select(.name=="TEAM-IDC-APP") | .defaultDomain' `
-clientID=`aws cognito-idp list-user-pool-clients --user-pool-id $cognitoUserpoolId | jq -r '.UserPoolClients[] | select(.ClientName | contains("clientWeb")) | .ClientId'`
+applicationURL=`aws amplify list-apps --output json | jq -r '.apps[] | select(.name=="TEAM-IDC-APP") | .defaultDomain' `
+clientID=`aws cognito-idp list-user-pool-clients --user-pool-id $cognitoUserpoolId --output json | jq -r '.UserPoolClients[] | select(.ClientName | contains("clientWeb")) | .ClientId'`
 
 hostedUIdomain=$cognitouserpoolhostedUIdomain.auth.$REGION.amazoncognito.com
 appURL=https://main.$applicationURL


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

By default the AWS CLI uses JSON as a output format. But when you have set your named profiles to for example YAML, the deployment scripts will not work. By supplying the `--output json` overwrite to the commands that use `jq` we ensure that the input of `jq` is indeed JSON.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
