### PR TITLE
fix: Support whitespace in group names

### DIFF
--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -33,6 +33,6 @@ aws cloudformation deploy --region $REGION --template-file template.yml \
 --parameter-overrides \
   Source=$EMAIL_SOURCE \
   Login=$IDC_LOGIN_URL \
-  teamAdminGroup=$TEAM_ADMIN_GROUP \
-  teamAuditGroup=$TEAM_AUDITOR_GROUP \
+  teamAdminGroup="$TEAM_ADMIN_GROUP" \
+  teamAuditGroup="$TEAM_AUDITOR_GROUP" \
 --no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM

--- a/deployment/parameters-template.sh
+++ b/deployment/parameters-template.sh
@@ -18,5 +18,5 @@ REGION=us-east-1
 TEAM_ACCOUNT=123456789101
 ORG_MASTER_PROFILE=org_master_profile
 TEAM_ACCOUNT_PROFILE=team_account_profile
-TEAM_ADMIN_GROUP=team_admin_group_name
-TEAM_AUDITOR_GROUP=team_auditor_group_name
+TEAM_ADMIN_GROUP="team_admin_group_name"
+TEAM_AUDITOR_GROUP="team_auditor_group_name"


### PR DESCRIPTION
*Description of changes:* Enclose variable in quotes to support whitespace in Identity Center group names. Without this, the command fails when there is a space in the group name.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
