### PR TITLE
Fix retrieval of all groups in the lambda function teamgetIdCGroups-main

### DIFF
--- a/amplify/backend/function/teamgetIdCGroups/src/index.py
+++ b/amplify/backend/function/teamgetIdCGroups/src/index.py
@@ -22,8 +22,10 @@ def list_idc_groups(IdentityStoreId):
         client = boto3.client('identitystore')
         p = client.get_paginator('list_groups')
         paginator = p.paginate(IdentityStoreId=IdentityStoreId)
+        all_groups = []
         for page in paginator:
-            return page["Groups"]
+            all_groups.extend(page["Groups"])
+        return all_groups
     except ClientError as e:
         print(e.response['Error']['Message'])
 


### PR DESCRIPTION
*Description of changes:*

the current code has a bug that only returns the first page of sso groups. The proposed implementation returns all groups, tested on our environment.
