### PR TITLE
Make it possible to add custom tags to CF (nested) stacks and underlying resources.

### DIFF
--- a/amplify/backend/tags.json
+++ b/amplify/backend/tags.json
@@ -1,10 +1,1 @@
-[
-  {
-    "Key": "user:Stack",
-    "Value": "{project-env}"
-  },
-  {
-    "Key": "user:Application",
-    "Value": "{project-name}"
-  }
-]
+[]

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -24,32 +24,9 @@ cd ..
 aws codecommit create-repository --repository-name team-idc-app --repository-description "Temporary Elevated Access Management (TEAM) Application"
 git remote remove origin
 git remote add origin codecommit::$REGION://team-idc-app
-
-# Part below will update tag keys and values in amplify/backend/tags.json
-IFS=' ' read -ra TAG_ARRAY <<< "$TAGS"
-
-output="["
-for tag in "${TAG_ARRAY[@]}"; do
-  IFS='=' read -ra pair <<< "$tag"
-  key="${pair[0]}"
-  value="${pair[1]}"
-  output+="\n  {\n    \"Key\": \"$key\",\n    \"Value\": \"$value\"\n  },"
-done
-
-output="${output%,}\n]"
-echo "$output" > ./amplify/backend/tags.json
-
-if git diff-index --quiet HEAD -- "./amplify/backend/tags.json"; then
-  echo "No changes to amplify/backend/tags.json."
-else
-  git add ./amplify/backend/tags.json
-  git commit -m "Update tags."
-fi
-
 git push origin main
 
 cd ./deployment
-
 if [[ ! -z "$TAGS" ]];
 then
   aws cloudformation deploy --region $REGION --template-file template.yml \
@@ -59,7 +36,8 @@ then
     Login=$IDC_LOGIN_URL \
     teamAdminGroup="$TEAM_ADMIN_GROUP" \
     teamAuditGroup="$TEAM_AUDITOR_GROUP" \
-  --tags "$TAGS" \
+    tags="$TAGS" \
+  --tags $TAGS \
   --no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM
 else
   aws cloudformation deploy --region $REGION --template-file template.yml \
@@ -69,5 +47,6 @@ else
     Login=$IDC_LOGIN_URL \
     teamAdminGroup="$TEAM_ADMIN_GROUP" \
     teamAuditGroup="$TEAM_AUDITOR_GROUP" \
+    tags="$TAGS" \
   --no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM
 fi

--- a/deployment/destroy.sh
+++ b/deployment/destroy.sh
@@ -1,27 +1,72 @@
 # Copyright 2023 Amazon Web Services, Inc
-#
+# 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#
+# 
 #     http://www.apache.org/licenses/LICENSE-2.0
-#
+# 
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 #!/usr/bin/env bash
+set -xe
 
 . "./parameters.sh"
 
 export AWS_PROFILE=$TEAM_ACCOUNT_PROFILE
 
-appId=`aws amplify list-apps --output json | jq -r '.apps[] | select(.name=="TEAM-IDC-APP") | .appId' `
-stackName=`aws amplify get-backend-environment --app-id $appId --environment-name main --output json | jq -r '.backendEnvironment | .stackName'`
+git remote remove origin
+git remote add origin codecommit::$REGION://team-idc-app
+git remote add team https://github.com/aws-samples/iam-identity-center-team.git
+git pull team main
 
-aws cloudformation delete-stack --stack-name $stackName
+# Part below will update tag keys and values in amplify/backend/tags.json
+IFS=' ' read -ra TAG_ARRAY <<< "$TAGS"
 
-aws cloudformation delete-stack --stack-name TEAM-IDC-APP
+output="["
+for tag in "${TAG_ARRAY[@]}"; do
+  IFS='=' read -ra pair <<< "$tag"
+  key="${pair[0]}"
+  value="${pair[1]}"
+  output+="\n  {\n    \"Key\": \"$key\",\n    \"Value\": \"$value\"\n  },"
+done
 
-aws codecommit delete-repository --repository-name team-idc-app
+output="${output%,}\n]"
+echo "$output" > ../amplify/backend/tags.json
+
+if [[ ! -z "$TAGS" ]];
+then
+  aws cloudformation deploy --region $REGION --template-file template.yml \
+  --stack-name TEAM-IDC-APP \
+  --parameter-overrides \
+    Source=$EMAIL_SOURCE \
+    Login=$IDC_LOGIN_URL \
+    teamAdminGroup="$TEAM_ADMIN_GROUP" \
+    teamAuditGroup="$TEAM_AUDITOR_GROUP" \
+  --tags "$TAGS" \
+  --no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM
+else
+  echo "update normal"
+  aws cloudformation deploy --region $REGION --template-file template.yml \
+  --stack-name TEAM-IDC-APP \
+  --parameter-overrides \
+    Source=$EMAIL_SOURCE \
+    Login=$IDC_LOGIN_URL \
+    teamAdminGroup="$TEAM_ADMIN_GROUP" \
+    teamAuditGroup="$TEAM_AUDITOR_GROUP" \
+  --no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM
+fi
+
+if git diff-index --quiet HEAD -- "../amplify/backend/tags.json"; then
+  echo "No changes to amplify/backend/tags.json."
+else
+  git add ../amplify/backend/tags.json
+  git commit -m "Update tags."
+fi
+
+git push origin main
+git remote remove team

--- a/deployment/destroy.sh
+++ b/deployment/destroy.sh
@@ -1,72 +1,27 @@
 # Copyright 2023 Amazon Web Services, Inc
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 #!/usr/bin/env bash
-set -xe
 
 . "./parameters.sh"
 
 export AWS_PROFILE=$TEAM_ACCOUNT_PROFILE
 
-git remote remove origin
-git remote add origin codecommit::$REGION://team-idc-app
-git remote add team https://github.com/aws-samples/iam-identity-center-team.git
-git pull team main
+appId=`aws amplify list-apps --output json | jq -r '.apps[] | select(.name=="TEAM-IDC-APP") | .appId' `
+stackName=`aws amplify get-backend-environment --app-id $appId --environment-name main --output json | jq -r '.backendEnvironment | .stackName'`
 
-# Part below will update tag keys and values in amplify/backend/tags.json
-IFS=' ' read -ra TAG_ARRAY <<< "$TAGS"
+aws cloudformation delete-stack --stack-name $stackName
 
-output="["
-for tag in "${TAG_ARRAY[@]}"; do
-  IFS='=' read -ra pair <<< "$tag"
-  key="${pair[0]}"
-  value="${pair[1]}"
-  output+="\n  {\n    \"Key\": \"$key\",\n    \"Value\": \"$value\"\n  },"
-done
+aws cloudformation delete-stack --stack-name TEAM-IDC-APP
 
-output="${output%,}\n]"
-echo "$output" > ../amplify/backend/tags.json
-
-if [[ ! -z "$TAGS" ]];
-then
-  aws cloudformation deploy --region $REGION --template-file template.yml \
-  --stack-name TEAM-IDC-APP \
-  --parameter-overrides \
-    Source=$EMAIL_SOURCE \
-    Login=$IDC_LOGIN_URL \
-    teamAdminGroup="$TEAM_ADMIN_GROUP" \
-    teamAuditGroup="$TEAM_AUDITOR_GROUP" \
-  --tags "$TAGS" \
-  --no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM
-else
-  echo "update normal"
-  aws cloudformation deploy --region $REGION --template-file template.yml \
-  --stack-name TEAM-IDC-APP \
-  --parameter-overrides \
-    Source=$EMAIL_SOURCE \
-    Login=$IDC_LOGIN_URL \
-    teamAdminGroup="$TEAM_ADMIN_GROUP" \
-    teamAuditGroup="$TEAM_AUDITOR_GROUP" \
-  --no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM
-fi
-
-if git diff-index --quiet HEAD -- "../amplify/backend/tags.json"; then
-  echo "No changes to amplify/backend/tags.json."
-else
-  git add ../amplify/backend/tags.json
-  git commit -m "Update tags."
-fi
-
-git push origin main
-git remote remove team
+aws codecommit delete-repository --repository-name team-idc-app

--- a/deployment/parameters-template.sh
+++ b/deployment/parameters-template.sh
@@ -20,3 +20,4 @@ ORG_MASTER_PROFILE=org_master_profile
 TEAM_ACCOUNT_PROFILE=team_account_profile
 TEAM_ADMIN_GROUP="team_admin_group_name"
 TEAM_AUDITOR_GROUP="team_auditor_group_name"
+TAGS="project=iam-identity-center-team environment=prod"

--- a/deployment/template.yml
+++ b/deployment/template.yml
@@ -13,6 +13,10 @@ Parameters:
   teamAuditGroup:
     Type: String
     Description: TEAM application Auditor group
+  tags:
+    Type: String
+    Description: TEAM application tags
+    Default: ""
 
 Resources:
   TriggerAmplifyBuild:
@@ -113,6 +117,8 @@ Resources:
           Value: !Ref teamAdminGroup
         - Name: TEAM_AUDITOR_GROUP
           Value: !Ref teamAuditGroup
+        - Name: TAGS
+          Value: !Ref tags
       Tags:
         - Key: Branch
           Value: main

--- a/deployment/update.sh
+++ b/deployment/update.sh
@@ -24,14 +24,29 @@ git remote add origin codecommit::$REGION://team-idc-app
 git remote add team https://github.com/aws-samples/iam-identity-center-team.git
 git pull team main
 
-aws cloudformation deploy --region $REGION --template-file template.yml \
---stack-name TEAM-IDC-APP \
---parameter-overrides \
-  Source=$EMAIL_SOURCE \
-  Login=$IDC_LOGIN_URL \
-  teamAdminGroup="$TEAM_ADMIN_GROUP" \
-  teamAuditGroup="$TEAM_AUDITOR_GROUP" \
---no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM
+if [[ ! -z "$TAGS" ]];
+then
+  aws cloudformation deploy --region $REGION --template-file template.yml \
+  --stack-name TEAM-IDC-APP \
+  --parameter-overrides \
+    Source=$EMAIL_SOURCE \
+    Login=$IDC_LOGIN_URL \
+    teamAdminGroup="$TEAM_ADMIN_GROUP" \
+    teamAuditGroup="$TEAM_AUDITOR_GROUP" \
+    tags="$TAGS" \
+  --tags $TAGS \
+  --no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM
+else
+  aws cloudformation deploy --region $REGION --template-file template.yml \
+  --stack-name TEAM-IDC-APP \
+  --parameter-overrides \
+    Source=$EMAIL_SOURCE \
+    Login=$IDC_LOGIN_URL \
+    teamAdminGroup="$TEAM_ADMIN_GROUP" \
+    teamAuditGroup="$TEAM_AUDITOR_GROUP" \
+    tags="$TAGS" \
+  --no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM
+fi
 
 git push origin main
 git remote remove team

--- a/docs/docs/deployment/deployment_process.md
+++ b/docs/docs/deployment/deployment_process.md
@@ -46,6 +46,7 @@ Create a new file named **parameters.sh** in the **deployment** directory. Copy 
 - **TEAM_ACCOUNT_PROFILE** - Named profile for TEAM Application deployment Account
 - **TEAM_ADMIN_GROUP** - Name of IAM Identity Center group for TEAM administrators
 - **TEAM_AUDITOR_GROUP** - Name of IAM Identity Center group for TEAM auditors
+- **TAGS** - Tags that should be propagated to nested stacks and underlying resources
 
 For example:
 
@@ -58,6 +59,7 @@ ORG_MASTER_PROFILE=OrgMAsterProfileName
 TEAM_ACCOUNT_PROFILE=TeamAccountProfileName
 TEAM_ADMIN_GROUP=team_admin_group_name
 TEAM_AUDITOR_GROUP=team_auditor_group_name
+TAGS="tag1=value1 tag2=value2"
 ```
 
 ---

--- a/parameters.js
+++ b/parameters.js
@@ -6,7 +6,7 @@
 const fs = require("fs");
 const path = require("path");
 
-const { AWS_APP_ID, AWS_BRANCH, EMAIL_SOURCE, SSO_LOGIN, TEAM_ADMIN_GROUP, TEAM_AUDITOR_GROUP } = process.env;
+const { AWS_APP_ID, AWS_BRANCH, EMAIL_SOURCE, SSO_LOGIN, TEAM_ADMIN_GROUP, TEAM_AUDITOR_GROUP, TAGS } = process.env;
 
 async function update_auth_parameters() {
   console.log(`updating amplify config for branch "${AWS_BRANCH}"...`);
@@ -87,7 +87,28 @@ async function update_groups_parameters() {
   );
 }
 
+async function update_tag_parameters() {
+  console.log(`updating amplify/backend/tags.json"...`);
+
+  const tagsParametersJsonPath = path.resolve(
+    `./amplify/backend/tags.json`
+  );
+
+  const tagsArray = TAGS ? TAGS.split(' ').map((tag) => {
+    const [key, value] = tag.split('=');
+    return {
+      Key: key,
+      Value: value,
+    };
+  }) : [];
+
+  fs.writeFileSync(tagsParametersJsonPath, JSON.stringify(tagsArray, null, 2));
+}
+
+
+
 update_custom_parameters();
 update_auth_parameters();
 update_react_parameters();
 update_groups_parameters();
+update_tag_parameters();


### PR DESCRIPTION
*Description of changes:*

We have to put certain tags (like project, stage, repository, ...) on every CF stack we deploy (and it propagates to (most) resources). 

Example of `parameters.sh` where we define the `TAGS`.

```
...
TEAM_ACCOUNT_PROFILE=test-team
TEAM_ADMIN_GROUP="xxx"
TEAM_AUDITOR_GROUP="yyy"
TAGS="project=iam-identity-center-team stage=prod repository=https://bitbucket.org/stuff other=test"
```

The updated bash scripts are maybe not the cleanest way to achieve this, but it helps me to clarify my use case.
It makes it possible to tag the CF stack for Amplify + all underlying nested stacks.

Tags can also be updated.
We can't hardcode the values in the `tags.json` because we have a stage tag: prod vs non-prod (in a test organization). We try to use a separate params.sh file for each environment. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
