### PR TITLE
refactor: nodejs14.x to nodejs18.x

### DIFF
--- a/amplify/backend/function/teamStatus/teamStatus-cloudformation-template.json
+++ b/amplify/backend/function/teamStatus/teamStatus-cloudformation-template.json
@@ -92,7 +92,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Layers": [],
         "Timeout": 25
       }

--- a/amplify/backend/function/teamgetLogs/teamgetLogs-cloudformation-template.json
+++ b/amplify/backend/function/teamgetLogs/teamgetLogs-cloudformation-template.json
@@ -103,7 +103,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Layers": [],
         "Timeout": 250
       }

--- a/amplify/backend/function/teamqueryLogs/teamqueryLogs-cloudformation-template.json
+++ b/amplify/backend/function/teamqueryLogs/teamqueryLogs-cloudformation-template.json
@@ -84,7 +84,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Layers": [],
         "Timeout": 250
       }


### PR DESCRIPTION
*Issue #, if available:* #50

*Description of changes:*
As per announcement of AWS:

> We are ending support for Node.js 14 in AWS Lambda. This follows Node.js 14 End-Of-Life (EOL) reached on April 30, 2023 [1].
>
> As described in the Lambda runtime support policy [2], end of support for language runtimes in Lambda happens in two stages. Starting November 27, 2023, Lambda will no longer apply security patches and other updates to the Node.js 14 runtime used by Lambda functions, and functions using Node.js 14 will no longer be eligible for technical support. In addition, you will no longer be able to create new Lambda functions using the Node.js 14 runtime. Starting January 25, 2024, you will no longer be able to update existing functions using the Node.js 14 runtime.
>
> We recommend that you upgrade your existing Node.js 14 functions to Node.js 18 before November 27, 2023.

For this reason I bumped the 3 lambda functions that were using nodejs14.x.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
