### PR TITLE
fix: use the team profile for codecommit origin

### DIFF
--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -1,11 +1,11 @@
 # Copyright 2022 Amazon Web Services, Inc
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,7 +23,7 @@ cd ..
 
 aws codecommit create-repository --repository-name team-idc-app --repository-description "Temporary Elevated Access Management (TEAM) Application"
 git remote remove origin
-git remote add origin codecommit::$REGION://team-idc-app
+git remote add origin codecommit::$REGION://$AWS_PROFILE@team-idc-app
 git push origin main
 
 cd ./deployment

--- a/deployment/update.sh
+++ b/deployment/update.sh
@@ -1,11 +1,11 @@
 # Copyright 2023 Amazon Web Services, Inc
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,7 @@ set -xe
 export AWS_PROFILE=$TEAM_ACCOUNT_PROFILE
 
 git remote remove origin
-git remote add origin codecommit::$REGION://team-idc-app
+git remote add origin codecommit::$REGION://$AWS_PROFILE@team-idc-app
 git remote add team https://github.com/aws-samples/iam-identity-center-team.git
 git pull team main
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When you have multiple accounts you most likely also have multiple AWS profiles. Since the codecommit repository is located in the team AWS Account it makes sense to explicitly use that profile for the origin configuration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
