### PR TITLE
Add version tag to solution.

### DIFF
--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -27,28 +27,31 @@ git remote add origin codecommit::$REGION://team-idc-app
 git push origin main
 
 cd ./deployment
+
+set +xe
+version=$(git describe --tags --abbrev=0 2>/dev/null)
+set -xe
+
+if [ -z "$version" ]; then
+    version=$(git rev-parse --short HEAD)
+fi
+
 if [[ ! -z "$TAGS" ]];
 then
-  aws cloudformation deploy --region $REGION --template-file template.yml \
-  --stack-name TEAM-IDC-APP \
-  --parameter-overrides \
-    Source=$EMAIL_SOURCE \
-    Login=$IDC_LOGIN_URL \
-    CloudTrailAuditLogs=$CLOUDTRAIL_AUDIT_LOGS \
-    teamAdminGroup="$TEAM_ADMIN_GROUP" \
-    teamAuditGroup="$TEAM_AUDITOR_GROUP" \
-    tags="$TAGS" \
-  --tags $TAGS \
-  --no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM
+    TAGS="$TAGS version=$version"
 else
-  aws cloudformation deploy --region $REGION --template-file template.yml \
-  --stack-name TEAM-IDC-APP \
-  --parameter-overrides \
-    Source=$EMAIL_SOURCE \
-    Login=$IDC_LOGIN_URL \
-    CloudTrailAuditLogs=$CLOUDTRAIL_AUDIT_LOGS \
-    teamAdminGroup="$TEAM_ADMIN_GROUP" \
-    teamAuditGroup="$TEAM_AUDITOR_GROUP" \
-    tags="$TAGS" \
-  --no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM
+    TAGS="version=$version"
 fi
+
+aws cloudformation deploy --region $REGION --template-file template.yml \
+--stack-name TEAM-IDC-APP \
+--parameter-overrides \
+  Source=$EMAIL_SOURCE \
+  BranchName=$BRANCH \
+  Login=$IDC_LOGIN_URL \
+  CloudTrailAuditLogs=$CLOUDTRAIL_AUDIT_LOGS \
+  teamAdminGroup="$TEAM_ADMIN_GROUP" \
+  teamAuditGroup="$TEAM_AUDITOR_GROUP" \
+  tags="$TAGS" \
+--tags $TAGS \
+--no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM

--- a/deployment/update.sh
+++ b/deployment/update.sh
@@ -24,31 +24,33 @@ git remote add origin codecommit::$REGION://team-idc-app
 git remote add team https://github.com/aws-samples/iam-identity-center-team.git
 git pull team main
 
+set +xe
+version=$(git describe --tags --abbrev=0 2>/dev/null)
+set -xe
+
+if [ -z "$version" ]; then
+    version=$(git rev-parse --short HEAD)
+fi
+
 if [[ ! -z "$TAGS" ]];
 then
-  aws cloudformation deploy --region $REGION --template-file template.yml \
-  --stack-name TEAM-IDC-APP \
-  --parameter-overrides \
-    Source=$EMAIL_SOURCE \
-    Login=$IDC_LOGIN_URL \
-    CloudTrailAuditLogs=$CLOUDTRAIL_AUDIT_LOGS \
-    teamAdminGroup="$TEAM_ADMIN_GROUP" \
-    teamAuditGroup="$TEAM_AUDITOR_GROUP" \
-    tags="$TAGS" \
-  --tags $TAGS \
-  --no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM
+    TAGS="$TAGS version=$version"
 else
-  aws cloudformation deploy --region $REGION --template-file template.yml \
-  --stack-name TEAM-IDC-APP \
-  --parameter-overrides \
-    Source=$EMAIL_SOURCE \
-    Login=$IDC_LOGIN_URL \
-    CloudTrailAuditLogs=$CLOUDTRAIL_AUDIT_LOGS \
-    teamAdminGroup="$TEAM_ADMIN_GROUP" \
-    teamAuditGroup="$TEAM_AUDITOR_GROUP" \
-    tags="$TAGS" \
-  --no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM
+    TAGS="version=$version"
 fi
+
+aws cloudformation deploy --region $REGION --template-file template.yml \
+--stack-name TEAM-IDC-APP \
+--parameter-overrides \
+  Source=$EMAIL_SOURCE \
+  BranchName=$BRANCH \
+  Login=$IDC_LOGIN_URL \
+  CloudTrailAuditLogs=$CLOUDTRAIL_AUDIT_LOGS \
+  teamAdminGroup="$TEAM_ADMIN_GROUP" \
+  teamAuditGroup="$TEAM_AUDITOR_GROUP" \
+  tags="$TAGS" \
+--tags $TAGS \
+--no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM
 
 git push origin main
 git remote remove team


### PR DESCRIPTION
*Issue #, if available:* 
#48

*Description of changes:*
Add a `version` tag to the solution:
* if there is a git tag for the current commit, then the version is that tag (e.g `v1.0.5`)
* if there is no git tag for the current commit, then the version is the commit hash (e.g. `a2749f3`)

There will always be at least one tag (the `version` tag), so we can remove the if/else for the `aws cloudformation deploy` step.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.