### PR TITLE
Fix backwards compatibility

### DIFF
--- a/deployment/template.yml
+++ b/deployment/template.yml
@@ -9,6 +9,12 @@ Parameters:
     Description: IAM IDC Login URL
   CloudTrailAuditLogs:
     Type: "String"
+    AllowedValues:
+      - read_write
+      - read
+      - write
+      - none
+      - ""
     Description: "Read and Write CloudTrail logs"
   teamAdminGroup:
     Type: String

--- a/deployment/template.yml
+++ b/deployment/template.yml
@@ -9,11 +9,6 @@ Parameters:
     Description: IAM IDC Login URL
   CloudTrailAuditLogs:
     Type: "String"
-    AllowedValues:
-      - read_write
-      - read
-      - write
-      - none
     Description: "Read and Write CloudTrail logs"
   teamAdminGroup:
     Type: String


### PR DESCRIPTION
Allow that `CloudTrailAuditLogs` can be empty. 

If you don't define `CLOUDTRAIL_AUDIT_LOGS` in `parameters.sh`, then it will deploy/update your solution using an empty value for that parameter:

```
aws cloudformation deploy ... --parameter-overrides ... CloudTrailAuditLogs= ...
```

Next the condition `IsEmptyCloudTrailAuditLogs` in our `template.yml` will be true. When the condition is true, we will pass the default value `read_write` to our Amplify branch.

```
  AmplifyBranch:
    Type: AWS::Amplify::Branch
    Properties:
      ...
      EnvironmentVariables: 
        - ...
        - Name: CLOUDTRAIL_AUDIT_LOGS
          Value: !If
            - IsEmptyCloudTrailAuditLogs
            - "read_write"
            - !Ref CloudTrailAuditLogs
```