### PR TITLE
Add default value of "" for CloudTrailAuditLogs

### DIFF
--- a/deployment/template.yml
+++ b/deployment/template.yml
@@ -16,6 +16,7 @@ Parameters:
       - none
       - ""
     Description: "Read and Write CloudTrail logs"
+    Default: ""
   teamAdminGroup:
     Type: String
     Description: TEAM application Admin group


### PR DESCRIPTION
Check "chicken/egg" comment here https://github.com/aws-samples/iam-identity-center-team/issues/77

The default value is probably necessary because the first time you try to run `./update.sh`, the CF deploy command will not contain `--parameter-overrides CloudTrailAuditLogs=$CLOUDTRAIL_AUDIT_LOGS \` inside the `update.sh` script.. That will be pulled but not loaded into the current execution of the script. Still, the `template.yml` will be updated because of these steps in the update script:

```
git remote add team https://github.com/aws-samples/iam-identity-center-team.git
git pull team main
```

By adding a default value, we allow that it's not necessary to define `--parameter-overrides CloudTrailAuditLogs=$CLOUDTRAIL_AUDIT_LOGS \` inside our script. This will solve issues during the first run of the script.

I hope it's still clear for you, this way of deploying can be confusing (pull changes of a script inside that same script).

