### PR TITLE
Fix: ticketNo not being referenced in Slack Notifications

### DIFF
--- a/amplify/backend/function/teamRouter/src/index.py
+++ b/amplify/backend/function/teamRouter/src/index.py
@@ -244,6 +244,7 @@ def get_request_data(data, expire, approval_required):
         "time": data["duration"]["S"],
         "startTime": data["startTime"]["S"],
         "justification": data["justification"]["S"],
+        "ticketNo": data.get("ticketNo", {}).get("S"),
         "approver": data.get("approver", {}).get("S"),
         "revoker": data.get("revoker", {}).get("S"),
         "instanceARN": sso_instance['InstanceArn'],


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
ticketNo is not currently being passed as part of the request data and subsequently is not referenced in any Slack Notifications. The value is always, "No ticket provided". This fix simply adds the ticketNo to the request data.

**Currently looks like the following:**
![Screenshot 2023-10-03 at 11 38 34 AM](https://github.com/aws-samples/iam-identity-center-team/assets/10668404/a80ff192-1c30-4f5b-b33b-8bc47aebb68d)



**After code changes:** 
![Screenshot 2023-10-03 at 11 40 37 AM](https://github.com/aws-samples/iam-identity-center-team/assets/10668404/46081b87-202a-4aab-beee-553db820177a)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
