### PR TITLE
feat: optional custom amplify domain

### DIFF
--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -42,6 +42,7 @@ then
     teamAuditGroup="$TEAM_AUDITOR_GROUP" \
     tags="$TAGS" \
     teamAccount="$TEAM_ACCOUNT" \
+    customAmplifyDomain="$UI_DOMAIN" \
   --tags $TAGS \
   --no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM
 else
@@ -54,5 +55,6 @@ else
     teamAuditGroup="$TEAM_AUDITOR_GROUP" \
     tags="$TAGS" \
     teamAccount="$TEAM_ACCOUNT" \
+    customAmplifyDomain="$UI_DOMAIN" \
   --no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM
 fi

--- a/deployment/integration.sh
+++ b/deployment/integration.sh
@@ -27,15 +27,22 @@ green='\033[0;32m'
 clear='\033[0m'
 cognitoUserpoolId=`aws cognito-idp list-user-pools --region $REGION --max-results 10 --output json | jq -r '.UserPools[] | select(.Name | contains("team06dbb7fc")) | .Id'`
 cognitouserpoolhostedUIdomain=`aws cognito-idp describe-user-pool --region $REGION --user-pool-id $cognitoUserpoolId --output json | jq -r '.UserPool.Domain'`
-applicationURL=`aws amplify list-apps --region $REGION --output json | jq -r '.apps[] | select(.name=="TEAM-IDC-APP") | .defaultDomain' `
-clientID=`aws cognito-idp list-user-pool-clients --region $REGION --user-pool-id $cognitoUserpoolId --output json | jq -r '.UserPoolClients[] | select(.ClientName | contains("clientWeb")) | .ClientId'`
+cognitoClientWebClientID=`aws cognito-idp list-user-pool-clients --region $REGION --user-pool-id $cognitoUserpoolId --output json | jq -r '.UserPoolClients[] | select(.ClientName | contains("clientWeb")) | .ClientId'`
+cognitoHostedUIdomain=$cognitouserpoolhostedUIdomain.auth.$REGION.amazoncognito.com
 
-hostedUIdomain=$cognitouserpoolhostedUIdomain.auth.$REGION.amazoncognito.com
-appURL=https://main.$applicationURL
+amplifyApp=$(aws amplify list-apps --output json | jq -r '.apps[] | select(.name=="TEAM-IDC-APP")' )
+amplifyAppId=$(echo $amplifyApp | jq -r '.appId' )
+amplifyDomain="$BRANCH.$(echo $amplifyApp | jq -r '.defaultDomain' )"
 
-applicationStartURL="https://$hostedUIdomain/authorize?client_id=$clientID&response_type=code&scope=aws.cognito.signin.user.admin+email+openid+phone+profile&redirect_uri=$appURL/&idp_identifier=team"
-applicationACSURL="https://$hostedUIdomain/saml2/idpresponse"
+amplifyCustomDomains=$(aws amplify list-domain-associations --app-id $amplifyAppId --output json)
+amplifyCustomDomain=$(echo $amplifyCustomDomains | jq -r 'select(.domainAssociations | length > 0) | .domainAssociations[0].domainName')
+if [ -n "$amplifyCustomDomain" ]; then
+  amplifyCustomDomainPrefix=$(echo $amplifyCustomDomains | jq -r 'select(.domainAssociations | length > 0) | .domainAssociations[0].subDomains[] | select(.subDomainSetting.branchName=="main") | .subDomainSetting.prefix')
+  amplifyDomain=$([ -z "$amplifyCustomDomainPrefix" ] && echo $amplifyCustomDomain || echo $amplifyCustomDomainPrefix.$amplifyCustomDomain)
+fi
+
+applicationStartURL="https://$cognitoHostedUIdomain/authorize?client_id=$cognitoClientWebClientID&response_type=code&scope=aws.cognito.signin.user.admin+email+openid+phone+profile&redirect_uri=https://$amplifyDomain/&idp_identifier=team"
+applicationACSURL="https://$cognitoHostedUIdomain/saml2/idpresponse"
 applicationSAMLAudience="urn:amazon:cognito:sp:$cognitoUserpoolId"
-
 
 printf "\n${green}applicationStartURL:${clear} %s\n${green}applicationACSURL:${clear} %s\n${green}applicationSAMLAudience:${clear} %s\n\n" "$applicationStartURL" "$applicationACSURL" "$applicationSAMLAudience"

--- a/deployment/parameters-mgmt-template.sh
+++ b/deployment/parameters-mgmt-template.sh
@@ -19,3 +19,4 @@ TEAM_ADMIN_GROUP="team_admin_group_name"
 TEAM_AUDITOR_GROUP="team_auditor_group_name"
 TAGS="project=iam-identity-center-team environment=prod"
 CLOUDTRAIL_AUDIT_LOGS=read_write
+UI_DOMAIN=

--- a/deployment/parameters-template.sh
+++ b/deployment/parameters-template.sh
@@ -21,3 +21,4 @@ TEAM_ADMIN_GROUP="team_admin_group_name"
 TEAM_AUDITOR_GROUP="team_auditor_group_name"
 TAGS="project=iam-identity-center-team environment=prod"
 CLOUDTRAIL_AUDIT_LOGS=read_write
+UI_DOMAIN=

--- a/deployment/template.yml
+++ b/deployment/template.yml
@@ -26,9 +26,14 @@ Parameters:
   teamAccount:
     Type: String
     Description: TEAM deployment account ID
+  customAmplifyDomain:
+    Type: String
+    Description: Custom domain for the TEAM application
+    Default: ""
 
 Conditions:
   IsEmptyCloudTrailAuditLogs: !Equals [!Ref CloudTrailAuditLogs, ""]
+  UseCustomAmplifyDomain: !Not [ !Equals [!Ref customAmplifyDomain, ""] ]
 
 Resources:
   TriggerAmplifyBuild:
@@ -136,6 +141,11 @@ Resources:
           Value: !Ref teamAuditGroup
         - Name: TAGS
           Value: !Ref tags
+        - Name: AMPLIFY_CUSTOM_DOMAIN
+          Value: !If
+            - UseCustomAmplifyDomain
+            - !Ref customAmplifyDomain
+            - !Ref AWS::NoValue
       Tags:
         - Key: Branch
           Value: main

--- a/deployment/update.sh
+++ b/deployment/update.sh
@@ -39,6 +39,7 @@ then
     teamAuditGroup="$TEAM_AUDITOR_GROUP" \
     tags="$TAGS" \
     teamAccount="$TEAM_ACCOUNT" \
+    customAmplifyDomain="$UI_DOMAIN" \
   --tags $TAGS \
   --no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM
 else
@@ -51,6 +52,7 @@ else
     teamAuditGroup="$TEAM_AUDITOR_GROUP" \
     tags="$TAGS" \
     teamAccount="$TEAM_ACCOUNT" \
+    customAmplifyDomain="$UI_DOMAIN" \
   --no-fail-on-empty-changeset --capabilities CAPABILITY_NAMED_IAM
 fi
 

--- a/docs/docs/deployment/deployment_process.md
+++ b/docs/docs/deployment/deployment_process.md
@@ -54,6 +54,7 @@ Optional:
   - `read` - record only read events
   - `write` - record only write events
   - `none` - disable event logging
+  - **UI_DOMAIN** - Custom domain for the Amplify Hosted UI (does not configure the Amplify app Domain Management, must be done if required).
 
 For example:
 
@@ -67,6 +68,7 @@ TEAM_ADMIN_GROUP="team_admin_group_name"
 TEAM_AUDITOR_GROUP="team_auditor_group_name"
 TAGS="tag1=value1 tag2=value2"
 CLOUDTRAIL_AUDIT_LOGS=read_write
+UI_DOMAIN=team.awsapps.com
 ```
 
 ---

--- a/parameters.js
+++ b/parameters.js
@@ -6,7 +6,7 @@
 const fs = require("fs");
 const path = require("path");
 
-const { AWS_APP_ID, AWS_BRANCH, SSO_LOGIN, TEAM_ADMIN_GROUP, TEAM_AUDITOR_GROUP, TAGS, CLOUDTRAIL_AUDIT_LOGS, TEAM_ACCOUNT } = process.env;
+const { AWS_APP_ID, AWS_BRANCH, SSO_LOGIN, TEAM_ADMIN_GROUP, TEAM_AUDITOR_GROUP, TAGS, CLOUDTRAIL_AUDIT_LOGS, TEAM_ACCOUNT, AMPLIFY_CUSTOM_DOMAIN } = process.env;
 
 async function update_auth_parameters() {
   console.log(`updating amplify config for branch "${AWS_BRANCH}"...`);
@@ -24,12 +24,12 @@ async function update_auth_parameters() {
   );
   oAuthMetadata.CallbackURLs.pop();
   oAuthMetadata.LogoutURLs.pop();
-  oAuthMetadata.CallbackURLs.push(
-    `https://${AWS_BRANCH}.${AWS_APP_ID}.amplifyapp.com/`
-  );
-  oAuthMetadata.LogoutURLs.push(
-    `https://${AWS_BRANCH}.${AWS_APP_ID}.amplifyapp.com/`
-  );
+
+  const amplifyDomain = `https://${AMPLIFY_CUSTOM_DOMAIN ? AMPLIFY_CUSTOM_DOMAIN : `${AWS_BRANCH}.${AWS_APP_ID}.amplifyapp.com`}/`;
+
+  oAuthMetadata.CallbackURLs.push(amplifyDomain);
+  oAuthMetadata.LogoutURLs.push(amplifyDomain);
+
   authParametersJson.cognitoConfig.oAuthMetadata =
     JSON.stringify(oAuthMetadata);
 


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws-samples/iam-identity-center-team/issues/32
Replaces https://github.com/aws-samples/iam-identity-center-team/pull/87

Description of changes:
- parameters.js is the main change, so the callback and logout URLs are set to the custom amplify domain.
- integration.sh updated to show custom domain when setting up/updating IIC app.
- template.yml wondered if it should also create AmplifyDomain, but seems like that setup can be quite specific (subdomains, include root, auto create) so took it back out. Can revisit if needed / can be standard setup

Have tested the changes to parameters.js and integration.sh (although with some additional bits not in the PR for custom cognito domains as well), but have a slightly different setup (deploy.sh/update.sh/template.yml).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
