### PR TITLE
fix: subject length to long

### DIFF
--- a/amplify/backend/function/teamNotifications/src/index.py
+++ b/amplify/backend/function/teamNotifications/src/index.py
@@ -218,7 +218,7 @@ def lambda_handler(event: dict, context):
                 slack_message = f"<mailto:{requester}|{requester}> requests access to AWS, please approve or reject this request in TEAM."
                 email_to_addresses = approvers
                 email_cc_addresses = [requester]
-                subject = f"{requester} requests access to AWS account {account} - TEAM"
+                subject = f"Requests access to AWS account for {account} - TEAM"
                 email_message_html = f'<html><body><p><b>{requester}</b> requests access to AWS, please <b>approve or reject this request</b> in <a href="{login_url}">TEAM</a>.</p><p><b>Account:</b> {account}<br /><b>Role:</b> {role}<br /><b>Start Time:</b> {request_start_time}<br /><b>Duration:</b> {duration_hours} hours<br /><b>Justification:</b> {justification}<br /><b>Ticket Number:</b> {ticket}<br /></p></body></html>'
         case "scheduled":
             # Don't need to send a notification if the request start time has already passed
@@ -231,7 +231,7 @@ def lambda_handler(event: dict, context):
             slack_message = f"Your AWS access session is scheduled."
             email_to_addresses = [requester]
             email_cc_addresses = []
-            subject = f"Scheduled access session for {requester} to AWS account {account} - TEAM"
+            subject = f"Scheduled access session for {account} - TEAM"
             email_message_html = f'<html><body><p>Your AWS access session is scheduled, please open <a href="{login_url}">TEAM</a> to manage requests.</p><p><b>Account:</b> {account}<br /><b>Role:</b> {role}<br /><b>Start Time:</b> {request_start_time}<br /><b>Duration:</b> {duration_hours} hours<br /><b>Justification:</b> {justification}<br /><b>Ticket Number:</b> {ticket}<br /></p></body></html>'
         case "expired":
             # Notify requester request expired
@@ -239,7 +239,7 @@ def lambda_handler(event: dict, context):
             slack_message = "Your AWS access request has expired."
             email_to_addresses = [requester]
             email_cc_addresses = approvers if approval_required else []
-            subject = f"Expired access request for {requester} to AWS account {account} - TEAM"
+            subject = f"Expired access request for {account} - TEAM"
             email_message_html = f'<html><body><p>Your AWS access request has expired, please open <a href="{login_url}">TEAM</a> to submit a new request.</p><p><b>Account:</b> {account}<br /><b>Role:</b> {role}<br /><b>Start Time:</b> {request_start_time}<br /><b>Duration:</b> {duration_hours} hours<br /><b>Justification:</b> {justification}<br /><b>Ticket Number:</b> {ticket}<br /></p></body></html>'
         case "ended":
             # Notify requester ended
@@ -247,7 +247,7 @@ def lambda_handler(event: dict, context):
             slack_message = "Your AWS access session has ended."
             email_to_addresses = [requester]
             email_cc_addresses = approvers if approval_required else []
-            subject = f"AWS access session ended for {requester} to AWS account {account} - TEAM"
+            subject = f"AWS access session ended for {account} - TEAM"
             email_message_html = f'<html><body><p>Your AWS access session has ended, please open <a href="{login_url}">TEAM</a> to view session activity logs.</p><p><b>Account:</b> {account}<br /><b>Role:</b> {role}<br /><b>Start Time:</b> {request_start_time}<br /><b>Duration:</b> {duration_hours} hours<br /><b>Justification:</b> {justification}<br /><b>Ticket Number:</b> {ticket}<br /></p></body></html>'
         case "granted":
             # Notify requester access granted
@@ -255,7 +255,7 @@ def lambda_handler(event: dict, context):
             slack_message = "Your AWS access session has started."
             email_to_addresses = [requester]
             email_cc_addresses = approvers if approval_required else []
-            subject = f"AWS access session started for {requester} to AWS account {account} - TEAM"
+            subject = f"AWS access session started for {account} - TEAM"
             email_message_html = f'<html><body><p>Your AWS access session has started. Open <a href="{login_url}">TEAM</a> to manage AWS access requests.</p><p><b>Account:</b> {account}<br /><b>Role:</b> {role}<br /><b>Start Time:</b> {request_start_time}<br /><b>Duration:</b> {duration_hours} hours<br /><b>Justification:</b> {justification}<br /><b>Ticket Number:</b> {ticket}<br /></p></body></html>'
         case "approved":
             # Notify requester request approved
@@ -265,7 +265,7 @@ def lambda_handler(event: dict, context):
             )
             email_to_addresses = [requester]
             email_cc_addresses = approvers
-            subject = f"AWS access request approved for {requester} to AWS account {account} - TEAM"
+            subject = f"AWS access request approved for {account} - TEAM"
             email_message_html = f'<html><body><p>Your AWS access request has been approved by {event["approver"]}. You will receive a notification when the session has started. Open <a href="{login_url}">TEAM</a> to manage AWS access requests.</p><p><b>Account:</b> {account}<br /><b>Role:</b> {role}<br /><b>Start Time:</b> {request_start_time}<br /><b>Duration:</b> {duration_hours} hours<br /><b>Justification:</b> {justification}<br /><b>Ticket Number:</b> {ticket}<br /></p></body></html>'
         case "rejected":
             # Notify requester request rejected
@@ -273,7 +273,7 @@ def lambda_handler(event: dict, context):
             slack_message = "Your AWS access request was rejected."
             email_to_addresses = [requester]
             email_cc_addresses = approvers
-            subject = f"AWS access request rejected for {requester} to AWS account {account} - TEAM"
+            subject = f"AWS access request rejected for {account} - TEAM"
             email_message_html = f'<html><body><p>Your AWS access request has been rejected. Open <a href="{login_url}">TEAM</a> to manage AWS access requests.</p><p><b>Account:</b> {account}<br /><b>Role:</b> {role}<br /><b>Start Time:</b> {request_start_time}<br /><b>Duration:</b> {duration_hours} hours<br /><b>Justification:</b> {justification}<br /><b>Ticket Number:</b> {ticket}<br /></p></body></html>'
         case "cancelled":
             # Notify approvers request cancelled
@@ -281,7 +281,7 @@ def lambda_handler(event: dict, context):
             slack_message = f"{requester} cancelled this AWS access request."
             email_to_addresses = approvers
             email_cc_addresses = [requester]
-            subject = f"AWS access request cancelled for {requester} to AWS account {account} - TEAM"
+            subject = f"AWS access request cancelled for {account} - TEAM"
             email_message_html = f'<html><body><p>{requester} cancelled an AWS access request. Open <a href="{login_url}">TEAM</a> to manage AWS access requests.</p><p><b>Account:</b> {account}<br /><b>Role:</b> {role}<br /><b>Start Time:</b> {request_start_time}<br /><b>Duration:</b> {duration_hours} hours<br /><b>Justification:</b> {justification}<br /><b>Ticket Number:</b> {ticket}<br /></p></body></html>'
         case "error":
             # Notify approvers and requester error
@@ -289,7 +289,7 @@ def lambda_handler(event: dict, context):
             slack_message = f"Error handling AWS access for {requester}. Error details: {event.get('statusError')}"
             email_to_addresses = [ses_source_email]
             email_cc_addresses = approvers + [requester]
-            subject = f"Error handling AWS access for {requester} to AWS account {account} - TEAM"
+            subject = f"Error handling AWS access for {account} - TEAM"
             email_message_html = f'<html><body><p>TEAM encountered an error handling AWS access for {requester}. Please review the Step Function logs to troubleshoot the error and ensure access is properly granted or revoked. Open <a href="{login_url}">TEAM</a> to view additional details.</p><p><b>Error Details:</b> {event.get("statusError")}<br /></p><p><b>Account:</b> {account}<br /><b>Role:</b> {role}<br /><b>Start Time:</b> {request_start_time}<br /><b>Duration:</b> {duration_hours} hours<br /><b>Justification:</b> {justification}<br /><b>Ticket Number:</b> {ticket}<br /></p></body></html>'
         case _:
             print(f"Request status unexpected, exiting: {request_status}")


### PR DESCRIPTION
*Issue #, if available:*
It looks like there's an issue with the TEAM application that arises when the SUBJECT of an Amazon Simple Notification Service (SNS) message is too long. The specific problem is that the TEAM application doesn't validate or limit the maximum length of a string variable, causing message sending to fail. The error is captured in CloudWatch, and a screenshot of the error has been provided.

![Screenshot 2023-12-07 at 13 06 21](https://github.com/aws-samples/iam-identity-center-team/assets/135218118/5f759d57-863a-4ab0-bc1c-8c8a1a4ad278)


*Description of changes:*
To address this issue, the proposed solution is to shorten the SUBJECT line by removing the {requester} variable, which can potentially be very long and contain a significant number of characters.  {requester} variable is the email address which is raising an request. The original long subject line includes the {requester} variable, and the modified shorter subject line omits it. Here's an example to illustrate the change:

example:
Long Subject Line (Original):
subject = f"{requester} requests access to AWS account {account} - TEAM"

Short Subject Line (Modified):
subject = f"Requests access to AWS account for {account} - TEAM"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
