### PR TITLE
Feature: Enable Machine Authentication to access Graph API Mutations

### DIFF
--- a/amplify/backend/api/team/schema.graphql
+++ b/amplify/backend/api/team/schema.graphql
@@ -67,6 +67,7 @@ type Approvers
   @auth(
     rules: [
       { allow: groups, groups: ["Admin"] }
+      { allow: groups, groupClaim: "scope", groups: ["api/admin"] }
       { allow: private, operations: [read] }
     ]
   ) {
@@ -83,6 +84,7 @@ type Settings
   @auth(
     rules: [
       { allow: groups, groups: ["Admin"] }
+      { allow: groups, groupClaim: "scope", groups: ["api/admin"] }
       { allow: private, operations: [read] }
     ]
   ) {
@@ -115,6 +117,7 @@ type Eligibility
   @auth(
     rules: [
       { allow: groups, groups: ["Admin"] }
+      { allow: groups, groupClaim: "scope", groups: ["api/admin"] }
       { allow: private, operations: [read] }
       { allow: private, provider: iam, operations: [read] }
     ]

--- a/deployment/api-machine-auth.sh
+++ b/deployment/api-machine-auth.sh
@@ -1,0 +1,47 @@
+# Copyright 2023 Amazon Web Services, Inc
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env bash
+
+. "./parameters.sh"
+
+if [ -z "$TEAM_ACCOUNT" ]; then 
+  export AWS_PROFILE=$ORG_MASTER_PROFILE
+else 
+  export AWS_PROFILE=$TEAM_ACCOUNT_PROFILE
+fi
+
+cognitoUserpoolId=`aws cognito-idp list-user-pools --region $REGION --max-results 10 --output json | jq -r '.UserPools[] | select(.Name | contains("team06dbb7fc")) | .Id'`
+
+# remove pager
+export AWS_PAGER=""
+
+# Create the resource server with the needed custom scopes
+aws cognito-idp create-resource-server --region $REGION \
+--user-pool-id $cognitoUserpoolId \
+--identifier "api" \
+--name "api" \
+--scopes "ScopeName=admin,ScopeDescription=Provides Admin access to machine authentication flows"
+
+# Create the user pool client with a secret access key to allow machine auth
+aws cognito-idp create-user-pool-client --region $REGION \
+--user-pool-id $cognitoUserpoolId \
+--client-name machine_auth \
+--generate-secret \
+--explicit-auth-flows "ALLOW_REFRESH_TOKEN_AUTH" \
+--supported-identity-providers "COGNITO" \
+--callback-urls "https://localhost" \
+--allowed-o-auth-flows "client_credentials" \
+--allowed-o-auth-scopes "api/admin" \
+--allowed-o-auth-flows-user-pool-client

--- a/docs/docs/deployment/configuration/cognito_machine_auth.md
+++ b/docs/docs/deployment/configuration/cognito_machine_auth.md
@@ -1,0 +1,41 @@
+---
+layout: default
+title: Cognito Machine Authentication Configuration 
+nav_order: 6
+parent: Configuration
+grand_parent: Solution deployment
+---
+
+# Cognito Machine Authentication Configuration 
+
+The TEAM Cognito machine authentication configuration is an optional configuration make the TEAM graph api accessible programmatically.
+
+### Run Api Machine Authentication configuration script
+The **api-machine-auth.sh** bash script in the **deployment** folder performs the following actions within the **TEAM_ACCOUNT**:
+
+- Creates a Resource Server with an id of `api` on the Cognito User Pool with a custom scope of `admin`.
+- Creates a User Pool Client on the Cognito User Pool with client secret generation enabled along with the other needed configuration for machine auth flows and allows it access to the `api/admin` custom scope.
+
+> Ensure that the named profile for the **TEAM Deployment account** has sufficient permissions before executing the **cognito.sh** script
+{: .important}
+
+Execute the following command in the root directory to deploy the script
+
+```sh
+cd deployment
+./api-machine-auth.sh
+```
+The **api-machine-auth.sh** script should be deployed successfully without any errors.
+
+The configuration to enable machine authentication against your AWS TEAM api is now complete.
+
+### Using Machine Authentication with the Graph API
+
+In order to use machine authentication on the Graph API, you need:
+1. Obtain the client Id and Secret from the Cognito User Pool Client named `machine_auth`. 
+2. Use these to obtain a token from the token endpoint for the Cognito User Pool. This process is detailed in the [AWS Cognito Guide](https://docs.aws.amazon.com/cognito/latest/developerguide/token-endpoint.html).
+3. Use this token in the `Authorization` header when making calls to the TEAM Graph API. 
+
+<!-- ### Using The Terraform Provider
+
+Documentation to come with the release of the terraform provider. -->

--- a/docs/docs/deployment/configuration/cognito_machine_auth.md
+++ b/docs/docs/deployment/configuration/cognito_machine_auth.md
@@ -11,12 +11,13 @@ grand_parent: Solution deployment
 The TEAM Cognito machine authentication configuration is an optional configuration make the TEAM graph api accessible programmatically.
 
 ### Run Api Machine Authentication configuration script
+
 The **api-machine-auth.sh** bash script in the **deployment** folder performs the following actions within the **TEAM_ACCOUNT**:
 
 - Creates a Resource Server with an id of `api` on the Cognito User Pool with a custom scope of `admin`.
 - Creates a User Pool Client on the Cognito User Pool with client secret generation enabled along with the other needed configuration for machine auth flows and allows it access to the `api/admin` custom scope.
 
-> Ensure that the named profile for the **TEAM Deployment account** has sufficient permissions before executing the **cognito.sh** script
+> Ensure that the named profile for the **TEAM Deployment account** has sufficient permissions before executing the **api-machine-auth.sh** script
 {: .important}
 
 Execute the following command in the root directory to deploy the script


### PR DESCRIPTION
*Issue #, if available:*
Closes: #33 

*Description of changes:*

This PR implements the following:
1. A script to automate the creation of the needed resources to enable machine authentication on the Cognito User pool: 
- Resource Server with a custom scope of `admin`
- User Pool Client with client secret generation enabled along with the other needed items for machine auth flows and assigned the `api/admin` custom scope.
2. Adds and `auth` rule on each mutation which currently allows full access to members of the `admin` group that grants the same level of access to machine authentication which uses the `api/admin` custom scope. 

I have tested these in or TEAM test environment and validated that I am able to perform the following:
1. Use the client_id and client_secret to obtain a token using the cognito user pool token endpoint.
2. Use this token to perform all queries.
3. Use this token to perform mutations on the `Settings`, `Approvers`, and `Eligibility` types. 

This work will further enable a terraform provider I have been writing for managing AWS TEAM. As this is my first contribution, please let me know if there is anything I am missing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
