### PR TITLE
Docs: Add terraform provider documentation reference and script for retrieving machine auth credentials

### DIFF
--- a/deployment/get-machine-auth-credentials.sh
+++ b/deployment/get-machine-auth-credentials.sh
@@ -1,0 +1,35 @@
+# Copyright 2023 Amazon Web Services, Inc
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env bash
+
+
+. "./parameters.sh"
+
+if [ -z "$TEAM_ACCOUNT" ]; then 
+  export AWS_PROFILE=$ORG_MASTER_PROFILE
+else 
+  export AWS_PROFILE=$TEAM_ACCOUNT_PROFILE
+fi
+
+cognitoUserpoolId=$(aws cognito-idp list-user-pools --region $REGION --max-results 10 --output json | jq -r '.UserPools[] | select(.Name | contains("team06dbb7fc")) | .Id')
+cognitoUserpoolDomain=$(aws cognito-idp describe-user-pool --region $REGION --user-pool-id $cognitoUserpoolId --output json | jq -r '.UserPool.Domain')
+cognitoUserpoolClientId=$(aws cognito-idp list-user-pool-clients --region $REGION --user-pool-id $cognitoUserpoolId --output json | jq -r '.UserPoolClients[] | select(.ClientName | contains("machine_auth")) | .ClientId')
+cognitoUserpoolClient=$(aws cognito-idp describe-user-pool-client --region $REGION --user-pool-id $cognitoUserpoolId --client-id $cognitoUserpoolClientId --output json | jq -r '.UserPoolClient')
+graphEndpoint=$(aws appsync list-graphql-apis --region $REGION --output json | jq -r '.graphqlApis[] | select(.name | contains("team-main")) | .uris.GRAPHQL')
+
+echo "token_endpoint=\"https://$cognitoUserpoolDomain.auth.$REGION.amazoncognito.com/oauth2/token\""
+echo "graph_endpoint=\"$graphEndpoint\""
+echo "client_id=$(echo $cognitoUserpoolClient | jq .ClientId)"
+echo "client_secret=$(echo $cognitoUserpoolClient | jq .ClientSecret)"

--- a/docs/docs/deployment/configuration/cognito_machine_auth.md
+++ b/docs/docs/deployment/configuration/cognito_machine_auth.md
@@ -30,13 +30,40 @@ The **api-machine-auth.sh** script should be deployed successfully without any e
 
 The configuration to enable machine authentication against your AWS TEAM api is now complete.
 
+### Retrieve Machine Authentication Credentials
+
+The simplest method to retrieve the machine authentication credentials is to run the **get-machine-auth-credentials.sh** script. The script will output the following information to your terminal: 
+
+- `token_endpoint` - The oath token endpoint for the configured aws cognito pool.
+- `graph_endpoint` - The graph endpoint for the TEAM deployment.
+- `client_id` - The client id of the `machine_auth` cognito user pool client.
+- `client_secret` - The client secret of the `machine_auth` cognito user pool client.
+
+> Ensure that the named profile for the **TEAM Deployment account** has sufficient permissions before executing the **get-machine-auth-credentials.sh** script
+{: .important}
+
+```sh
+cd deployment
+./get-machine-auth-credentials.sh
+# example script output
+token_endpoint="https://my.token.endpoint/oauth2/token"
+graph_endpoint="https://my.graph.endpoint/graphql"
+client_id="MyClientID"
+client_secret="MyClientSecret"
+```
+
+These credentials can then be used for accessing the TEAM graph api programmatically with the language of your choice and can also be used to configure the [terraform provider for awsteam](https://registry.terraform.io/providers/brittandeyoung/awsteam/latest). 
+
+
 ### Using Machine Authentication with the Graph API
 
 In order to use machine authentication on the Graph API, you need:
-1. Obtain the client Id and Secret from the Cognito User Pool Client named `machine_auth`. 
+1. Obtain the client Id and Secret from the Cognito User Pool Client named `machine_auth` or using the **get-machine-auth-credentials.sh** script.
 2. Use these to obtain a token from the token endpoint for the Cognito User Pool. This process is detailed in the [AWS Cognito Guide](https://docs.aws.amazon.com/cognito/latest/developerguide/token-endpoint.html).
 3. Use this token in the `Authorization` header when making calls to the TEAM Graph API. 
 
-<!-- ### Using The Terraform Provider
+### Using The Terraform Provider
 
-Documentation to come with the release of the terraform provider. -->
+There is a community maintained [terraform provider for awsteam](https://registry.terraform.io/providers/brittandeyoung/awsteam/latest). This allows managing configuration using terraform. You will need the machine authentication credentials in order to use this provider. 
+
+When reporting issues or wanting to collaborate on the provider, please work directly on the [provider's github page](https://github.com/brittandeyoung/terraform-provider-awsteam)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds two things:
1. The `get-machine-auth-credentials.sh` script. This script automates retrieving the credentials and endpoints needed for utilizing the graphql endpoint programatically.
3. Documentation on how to use the newly added script and reference to the newly published terraform provider. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
