### PR TITLE
fix: replace deprecated list_users by username filter with get_user_id

### DIFF
--- a/amplify/backend/function/teamRouter/custom-policies.json
+++ b/amplify/backend/function/teamRouter/custom-policies.json
@@ -1,6 +1,7 @@
 [
   {
-    "Action": ["identitystore:ListUsers"],
+    "Action": ["identitystore:ListUsers",
+                "identitystore:GetUserId"],
     "Resource": ["*"]
   },
   {

--- a/amplify/backend/function/teamRouter/src/index.py
+++ b/amplify/backend/function/teamRouter/src/index.py
@@ -196,17 +196,17 @@ def list_existing_sso_instances():
 def get_user(username):
     try:
         client = boto3.client('identitystore')
-        response = client.list_users(
+        response = client.get_user_id(
             IdentityStoreId=sso_instance['IdentityStoreId'],
-            Filters=[
-                {
-                    'AttributePath': 'UserName',
+            AlternateIdentifier={
+                'UniqueAttribute': {
+                    'AttributePath': 'userName',
                     'AttributeValue': username
                 },
-            ]
+            }
         )
-        if response['Users']:
-            return response['Users'][0]['UserId']
+        if response['UserId']:
+            return response['UserId']
         else:
             return
     except ClientError as e:

--- a/amplify/backend/function/teamgetGroups/custom-policies.json
+++ b/amplify/backend/function/teamgetGroups/custom-policies.json
@@ -1,6 +1,6 @@
 [
   {
-    "Action": ["identitystore:ListUsers"],
+    "Action": ["identitystore:GetUserId"],
     "Resource": ["*"]
   },
   {

--- a/amplify/backend/function/teamgetGroups/src/index.py
+++ b/amplify/backend/function/teamgetGroups/src/index.py
@@ -72,16 +72,16 @@ sso_instance = get_identity_store_id()
 def get_user(username):
     try:
         client = boto3.client('identitystore')
-        response = client.list_users(
+        response = client.get_user_id(
             IdentityStoreId=sso_instance,
-            Filters=[
-                {
-                    'AttributePath': 'UserName',
+            AlternateIdentifier={
+                'UniqueAttribute': {
+                    'AttributePath': 'userName',
                     'AttributeValue': username
                 },
-            ]
+            }
         )
-        return response['Users'][0]['UserId']
+        return response['UserId']
     except ClientError as e:
         print(e.response['Error']['Message'])
 


### PR DESCRIPTION
*Issue #, if available:* #150

*Description of changes:*

From [ListUsers](https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_ListUsers.html)
> Filtering for a User by the UserName attribute is deprecated. Instead, use the GetUserId API action.
Now need to use [GetUserId](https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_GetUserId.html)

4 occurrences in code: [search: list_users](https://github.com/search?q=repo%3Aaws-samples%2Fiam-identity-center-team%20list_users&type=code)

- teamRouter: used twice, one needs updating. Add GetUserId permission
- teamGetUsers: used once, not with filter, no update needed
- teamGetGroups: used once, swap and replace ListUser permission with GetUserId

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
