### PR TITLE
FEATURE: Support for existing CloudTrail Lake EDS

### DIFF
--- a/amplify/backend/custom/cloudtrailLake/cloudtrailLake-cloudformation-template.json
+++ b/amplify/backend/custom/cloudtrailLake/cloudtrailLake-cloudformation-template.json
@@ -6,12 +6,7 @@
     },
     "CloudTrailAuditLogs":{
       "Type":"String",
-      "AllowedValues":[
-        "read_write",
-        "read",
-        "write",
-        "none"
-      ]
+      "AllowedPattern": "(read_write|read|write|none|arn.*)"
     }
   },
   "Conditions":{
@@ -50,10 +45,47 @@
         },
         "none"
       ]
+    },
+    "CreateEventDataStore": {
+      "Fn::Or": [
+        {
+          "Fn::Equals": [
+            "none",
+            {
+              "Ref": "CloudTrailAuditLogs"
+            }
+          ]
+        },
+        {
+          "Fn::Equals": [
+            "read",
+            {
+              "Ref": "CloudTrailAuditLogs"
+            }
+          ]
+        },
+        {
+          "Fn::Equals": [
+            "read_write",
+            {
+              "Ref": "CloudTrailAuditLogs"
+            }
+          ]
+        },
+        {
+          "Fn::Equals": [
+            "write",
+            {
+              "Ref": "CloudTrailAuditLogs"
+            }
+          ]
+        }
+      ]
     }
   },
   "Resources":{
     "myEventDataStore":{
+      "Condition": "CreateEventDataStore",
       "Type":"AWS::CloudTrail::EventDataStore",
       "Properties":{
         "Name":{
@@ -123,8 +155,16 @@
   "Outputs":{
     "EventDataStoreOutput":{
       "Description":"The event data store ID",
-      "Value":{
-        "Ref":"myEventDataStore"
+      "Value": {
+        "Fn::If": [
+          "CreateEventDataStore",
+          {
+            "Ref": "myEventDataStore"
+          },
+          {
+            "Ref": "CloudTrailAuditLogs"
+          }
+        ]
       }
     }
   }

--- a/deployment/template.yml
+++ b/deployment/template.yml
@@ -6,13 +6,8 @@ Parameters:
     Description: IAM IDC Login URL
   CloudTrailAuditLogs:
     Type: "String"
-    AllowedValues:
-      - read_write
-      - read
-      - write
-      - none
-      - ""
-    Description: "Read and Write CloudTrail logs"
+    AllowedPattern: "(read_write|read|write|none|arn.*)"
+    Description: Which events should be logged on the TEAM Application Cloudtrail Lake EventDataStore.  Acceptable values are "read","write","read_write", and "none".  You may also enter the arn of an existing Cloudtrail Lake EDS.
   teamAdminGroup:
     Type: String
     Description: TEAM application Admin group

--- a/docs/docs/deployment/deployment_process.md
+++ b/docs/docs/deployment/deployment_process.md
@@ -62,7 +62,9 @@ Optional:
   - `read` - record only read events
   - `write` - record only write events
   - `none` - disable event logging
+  - `arn:aws:cloudtrail:*` - use an existing CloudTrail Event Data Store
 - **UI_DOMAIN** - Custom domain for Amplify hosted frontend application 
+
 
 For example:
 


### PR DESCRIPTION
*Description of changes:* Adding in support for passing an existing Cloudtrail Lake EventDataStore to TEAM by extending the use of the CloudTrailAuditLogs parameter to accept an ARN.
 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
