### PR TITLE
Update GraphQL schema to allow IAM auth for eligibility and approvers

### DIFF
--- a/amplify/backend/api/team/schema.graphql
+++ b/amplify/backend/api/team/schema.graphql
@@ -69,6 +69,7 @@ type Approvers
       { allow: groups, groups: ["Admin"] }
       { allow: groups, groupClaim: "scope", groups: ["api/admin"] }
       { allow: private, operations: [read] }
+      { allow: private, provider: iam, operations: [read, update] }
     ]
   ) {
   id: ID
@@ -119,7 +120,7 @@ type Eligibility
       { allow: groups, groups: ["Admin"] }
       { allow: groups, groupClaim: "scope", groups: ["api/admin"] }
       { allow: private, operations: [read] }
-      { allow: private, provider: iam, operations: [read] }
+      { allow: private, provider: iam, operations: [read, update] }
     ]
   ) {
   id: ID


### PR DESCRIPTION
*Description of changes:* 
Small change to allow graphql read/update to IAM principals. This allows for integration of TEAM AppSync API with Eventbridge.

Models impacted:
- Eligibility
- Approvers


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
