### PR TITLE
Deprecated lambda runtimes #156

### DIFF
--- a/deployment/template.yml
+++ b/deployment/template.yml
@@ -88,7 +88,8 @@ Resources:
           phases:
             preBuild:
               commands:
-                - npm i -g @aws-amplify/cli@10.7.3
+                - '# 12.0.1 Updates auth lambdas to node18'
+                - npm i -g @aws-amplify/cli@12.10.1
                 - '# Update deployment parameters with helper script'
                 - node parameters.js
             build:


### PR DESCRIPTION
Bump amplify CLI Version

*Issue #, if available:*
Issue 156
*Description of changes:*
Bumps Amplify CLI to later version which uses node18 for the cognito auth lambdas.

This shouldn't impact existing deployments of the auth lambdas.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
