### PR TITLE
FEATURE/AllowAdminToSeeAuditorPages

### DIFF
--- a/src/components/Navigation/Nav.js
+++ b/src/components/Navigation/Nav.js
@@ -164,7 +164,7 @@ function Nav(props) {
                     />
                   </Route>
                 ) : null}
-                {group && group.includes("Auditors") ? (
+                { group && ( group.includes("Auditors") || group.includes("Admin") )  ? (
                   <Route path="/audit/approvals">
                     <AuditApprovals
                       addNotification={setNotifications}
@@ -174,7 +174,7 @@ function Nav(props) {
                     />
                   </Route>
                 ) : null}
-                {group && group.includes("Auditors") ? (
+                { group && ( group.includes("Auditors") || group.includes("Admin") )  ? (
                   <Route path="/audit/sessions">
                     <AuditSessions
                       addNotification={setNotifications}

--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -41,8 +41,9 @@ function Navigation(props) {
             { type: "link", text: "Ended access", href: "/sessions/audit" },
           ],
         },
-        props.group && props.group.includes("Auditors") && props.cognitoGroups.includes("Auditors")
-          ? {
+        props.group && ( ( props.group.includes("Auditors") && props.cognitoGroups.includes("Auditors") || (props.group.includes("Admin") && props.cognitoGroups.includes("Admin") ) ))
+        ? { 
+          
               type: "section",
               text: "Audit",
               items: [


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Small change to improve admin functionality.  This will allow Admins to see Auditor pages (which they already have permissions to access via graphql.  Purely a frontend change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
