### PR TITLE
feature: support unicode for comment and justification

### DIFF
--- a/amplify/backend/api/team/resolvers/Mutation.createRequests.init.1.req.vtl
+++ b/amplify/backend/api/team/resolvers/Mutation.createRequests.init.1.req.vtl
@@ -19,7 +19,7 @@ $util.qr($ctx.stash.defaultValues.put("status", "pending"))
 #end
 
 #if (($ctx.args.input.ticketNo != '' && !$util.matches("[A-Za-z0-9]", $ctx.args.input.ticketNo.substring(0,1))) || 
-     !$util.matches("[A-Za-z0-9]", $ctx.args.input.justification.substring(0,1)))
+     !$util.matches("[\p{IsAlphabetic}\p{Digit}]", $ctx.args.input.justification.substring(0,1)))
     	$util.error('Invalid input')
 #end
 

--- a/amplify/backend/api/team/resolvers/Mutation.updateRequests.init.1.req.vtl
+++ b/amplify/backend/api/team/resolvers/Mutation.updateRequests.init.1.req.vtl
@@ -3,7 +3,7 @@ $util.qr($ctx.stash.put("defaultValues", $util.defaultIfNull($ctx.stash.defaultV
 #set( $updatedAt = $util.time.nowISO8601() )
 $util.qr($ctx.stash.defaultValues.put("updatedAt", $updatedAt))
 
-#if ($ctx.args.input.comment && !$util.matches("[A-Za-z0-9]", $ctx.args.input.comment.substring(0,1)))
+#if ($ctx.args.input.comment && !$util.matches("[\p{IsAlphabetic}\p{Digit}]", $ctx.args.input.comment.substring(0,1)))
     	$util.error('Invalid input')
 #end
 

--- a/src/components/Approvals/Approvals.js
+++ b/src/components/Approvals/Approvals.js
@@ -332,7 +332,7 @@ function Approvals(props) {
   }
 
   function handleAction() {
-    (!comment && commentRequired) || (comment && !(/^[a-zA-Z0-9]+$/.test(comment[0]))) ? setCommentError("Enter valid reason for approving or rejecting request") : submit();
+    (!comment && commentRequired) || (comment && !(/[\p{L}\p{N}]/u.test(comment[0]))) ? setCommentError("Enter valid reason for approving or rejecting request") : submit();
   }
 
   return (

--- a/src/components/Requests/Request.js
+++ b/src/components/Requests/Request.js
@@ -245,7 +245,7 @@ function Request(props) {
       setTimeError("Select start date");
       error = true;
     }
-    if (!justification || !/^[a-zA-Z0-9]+$/.test(justification[0])) {
+    if (!justification || !/[\p{L}\p{N}]/u.test(justification[0])) {
       setJustificationError("Enter valid business justification");
       error = true;
     }

--- a/src/components/Sessions/Active.js
+++ b/src/components/Sessions/Active.js
@@ -377,7 +377,7 @@ function Active(props) {
     });
   }
   function handleRevoke() {
-    (!comment && commentRequired) || (comment && !(/^[a-zA-Z0-9]+$/.test(comment[0]))) ? setCommentError("Enter valid reason for revoking elevated access") : revoke();
+    (!comment && commentRequired) || (comment && !(/[\p{L}\p{N}]/u.test(comment[0]))) ? setCommentError("Enter valid reason for revoking elevated access") : revoke();
   }
 
   return (


### PR DESCRIPTION
*Issue #, if available:*
resolve https://github.com/aws-samples/iam-identity-center-team/issues/163

*Description of changes:*
I changed regexp for validation of comment and justification to support unicode characters. 
So, users should be able to use Japanese and some other Asian languages.

I tested my regexp with some samples, please check if this is appropriate behavior.

<details><summary>Backend (click to open) </summary>
<p>

```
$util.matches("[\p{IsAlphabetic}\p{Digit}]", "A") ## upper     -> true
$util.matches("[\p{IsAlphabetic}\p{Digit}]", "a") ## lower     -> true
$util.matches("[\p{IsAlphabetic}\p{Digit}]", "1") ## number    -> true
$util.matches("[\p{IsAlphabetic}\p{Digit}]", "あ") ## Japanese -> true
$util.matches("[\p{IsAlphabetic}\p{Digit}]", "아") ## Korean   -> true
$util.matches("[\p{IsAlphabetic}\p{Digit}]", "你") ## Chinese  -> true
$util.matches("[\p{IsAlphabetic}\p{Digit}]", " ") ## space     -> false
$util.matches("[\p{IsAlphabetic}\p{Digit}]", "!") ## symbol    -> false
$util.matches("[\p{IsAlphabetic}\p{Digit}]", "	") ## tab      -> false
$util.matches("[\p{IsAlphabetic}\p{Digit}]", "") ## empty      -> false
```

</p>
</details> 

<details><summary>Frontend (click to open) </summary>
<p>

```
bash-5.2$ cat t.js
var arr = ['A', 'a', 1, 'あ', '아', '你', ' ', '!', '  ', '' ];

for (const elem of arr) {
  console.log(elem + ": " + /[\p{L}\p{N}]/u.test(elem))
}
bash-5.2$ node t.js
A: true
a: true
1: true
あ: true
아: true
你: true
 : false
!: false
  : false
: false
bash-5.2$
```

</p>
</details> 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
