### PR TITLE
add dependabot for github action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add dependabot to automatically update github actions.
Main issue with the current action - https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
