### PR TITLE
Update all Lambda's to Graviton

### DIFF
--- a/amplify/backend/custom/s3bucketSecurity/s3bucketSecurity-cloudformation-template.json
+++ b/amplify/backend/custom/s3bucketSecurity/s3bucketSecurity-cloudformation-template.json
@@ -135,6 +135,9 @@
     "LambdaFunction": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
+        "Architectures": [
+          "arm64"
+        ],
         "Runtime": "python3.9",
         "FunctionName": {
           "Fn::Join": [

--- a/amplify/backend/function/teamListGroups/teamListGroups-cloudformation-template.json
+++ b/amplify/backend/function/teamListGroups/teamListGroups-cloudformation-template.json
@@ -39,6 +39,9 @@
         "aws:asset:property": "Code"
       },
       "Properties": {
+        "Architectures": [
+          "arm64"
+        ],
         "Code": {
           "S3Bucket": {
             "Ref": "deploymentBucketName"

--- a/amplify/backend/function/teamNotifications/teamNotifications-cloudformation-template.json
+++ b/amplify/backend/function/teamNotifications/teamNotifications-cloudformation-template.json
@@ -34,6 +34,9 @@
         "aws:asset:property": "Code"
       },
       "Properties": {
+        "Architectures": [
+          "arm64"
+        ],
         "Code": {
           "S3Bucket": {
             "Ref": "deploymentBucketName"

--- a/amplify/backend/function/teamRouter/teamRouter-cloudformation-template.json
+++ b/amplify/backend/function/teamRouter/teamRouter-cloudformation-template.json
@@ -78,6 +78,9 @@
         "aws:asset:property": "Code"
       },
       "Properties": {
+        "Architectures": [
+          "arm64"
+        ],
         "Code": {
           "S3Bucket": {
             "Ref": "deploymentBucketName"

--- a/amplify/backend/function/teamStatus/teamStatus-cloudformation-template.json
+++ b/amplify/backend/function/teamStatus/teamStatus-cloudformation-template.json
@@ -43,6 +43,9 @@
         "aws:asset:property": "Code"
       },
       "Properties": {
+        "Architectures": [
+          "arm64"
+        ],
         "Code": {
           "S3Bucket": {
             "Ref": "deploymentBucketName"

--- a/amplify/backend/function/teamgetAccounts/teamgetAccounts-cloudformation-template.json
+++ b/amplify/backend/function/teamgetAccounts/teamgetAccounts-cloudformation-template.json
@@ -35,6 +35,9 @@
         "aws:asset:property": "Code"
       },
       "Properties": {
+        "Architectures": [
+          "arm64"
+        ],
         "Code": {
           "S3Bucket": {
             "Ref": "deploymentBucketName"

--- a/amplify/backend/function/teamgetEntitlement/teamgetEntitlement-cloudformation-template.json
+++ b/amplify/backend/function/teamgetEntitlement/teamgetEntitlement-cloudformation-template.json
@@ -43,6 +43,9 @@
         "aws:asset:property": "Code"
       },
       "Properties": {
+        "Architectures": [
+          "arm64"
+        ],
         "Code": {
           "S3Bucket": {
             "Ref": "deploymentBucketName"

--- a/amplify/backend/function/teamgetGroups/teamgetGroups-cloudformation-template.json
+++ b/amplify/backend/function/teamgetGroups/teamgetGroups-cloudformation-template.json
@@ -52,6 +52,9 @@
         "aws:asset:property": "Code"
       },
       "Properties": {
+        "Architectures": [
+          "arm64"
+        ],
         "Code": {
           "S3Bucket": {
             "Ref": "deploymentBucketName"

--- a/amplify/backend/function/teamgetIdCGroups/teamgetIdCGroups-cloudformation-template.json
+++ b/amplify/backend/function/teamgetIdCGroups/teamgetIdCGroups-cloudformation-template.json
@@ -35,6 +35,9 @@
         "aws:asset:property": "Code"
       },
       "Properties": {
+        "Architectures": [
+          "arm64"
+        ],
         "Code": {
           "S3Bucket": {
             "Ref": "deploymentBucketName"

--- a/amplify/backend/function/teamgetLogs/teamgetLogs-cloudformation-template.json
+++ b/amplify/backend/function/teamgetLogs/teamgetLogs-cloudformation-template.json
@@ -46,6 +46,9 @@
         "aws:asset:property": "Code"
       },
       "Properties": {
+        "Architectures": [
+          "arm64"
+        ],
         "Code": {
           "S3Bucket": {
             "Ref": "deploymentBucketName"

--- a/amplify/backend/function/teamgetMgmtAccountDetails/teamgetMgmtAccountDetails-cloudformation-template.json
+++ b/amplify/backend/function/teamgetMgmtAccountDetails/teamgetMgmtAccountDetails-cloudformation-template.json
@@ -35,6 +35,9 @@
         "aws:asset:property": "Code"
       },
       "Properties": {
+        "Architectures": [
+          "arm64"
+        ],
         "Code": {
           "S3Bucket": {
             "Ref": "deploymentBucketName"

--- a/amplify/backend/function/teamgetOU/teamgetOU-cloudformation-template.json
+++ b/amplify/backend/function/teamgetOU/teamgetOU-cloudformation-template.json
@@ -35,6 +35,9 @@
         "aws:asset:property": "Code"
       },
       "Properties": {
+        "Architectures": [
+          "arm64"
+        ],
         "Code": {
           "S3Bucket": {
             "Ref": "deploymentBucketName"

--- a/amplify/backend/function/teamgetOUs/teamgetOUs-cloudformation-template.json
+++ b/amplify/backend/function/teamgetOUs/teamgetOUs-cloudformation-template.json
@@ -35,6 +35,9 @@
         "aws:asset:property": "Code"
       },
       "Properties": {
+        "Architectures": [
+          "arm64"
+        ],
         "Code": {
           "S3Bucket": {
             "Ref": "deploymentBucketName"

--- a/amplify/backend/function/teamgetPermissions/teamgetPermissions-cloudformation-template.json
+++ b/amplify/backend/function/teamgetPermissions/teamgetPermissions-cloudformation-template.json
@@ -35,6 +35,9 @@
         "aws:asset:property": "Code"
       },
       "Properties": {
+        "Architectures": [
+          "arm64"
+        ],
         "Code": {
           "S3Bucket": {
             "Ref": "deploymentBucketName"

--- a/amplify/backend/function/teamgetUserPolicy/teamgetUserPolicy-cloudformation-template.json
+++ b/amplify/backend/function/teamgetUserPolicy/teamgetUserPolicy-cloudformation-template.json
@@ -39,6 +39,9 @@
         "aws:asset:property": "Code"
       },
       "Properties": {
+        "Architectures": [
+          "arm64"
+        ],
         "Code": {
           "S3Bucket": {
             "Ref": "deploymentBucketName"

--- a/amplify/backend/function/teamgetUsers/teamgetUsers-cloudformation-template.json
+++ b/amplify/backend/function/teamgetUsers/teamgetUsers-cloudformation-template.json
@@ -43,6 +43,9 @@
         "aws:asset:property": "Code"
       },
       "Properties": {
+        "Architectures": [
+          "arm64"
+        ],
         "Code": {
           "S3Bucket": {
             "Ref": "deploymentBucketName"

--- a/amplify/backend/function/teamqueryLogs/teamqueryLogs-cloudformation-template.json
+++ b/amplify/backend/function/teamqueryLogs/teamqueryLogs-cloudformation-template.json
@@ -38,6 +38,9 @@
         "aws:asset:property": "Code"
       },
       "Properties": {
+        "Architectures": [
+          "arm64"
+        ],
         "Code": {
           "S3Bucket": {
             "Ref": "deploymentBucketName"

--- a/deployment/template.yml
+++ b/deployment/template.yml
@@ -151,6 +151,8 @@ Resources:
       Runtime: python3.9
       Role: !GetAtt AmplifyLambdaRole.Arn
       Timeout: 120
+      Architectures:
+        - arm64
       Code:
         ZipFile: |
           import json


### PR DESCRIPTION
A PR for  Cost/Performance improvements. All the Lambda's run with "simple Python" so not sure if there is a reason why these Lambda's are not running on Graviton.

