### PR TITLE
feat: allow multiple eligibility policies with the same group

### DIFF
--- a/amplify/backend/api/team/schema.graphql
+++ b/amplify/backend/api/team/schema.graphql
@@ -124,6 +124,11 @@ type Eligibility
     ]
   ) {
   id: ID
+  entityId: String
+    @index(
+      name: "byEntityId"
+      queryField: "requestByEntityId"
+    )
   name: String
   type: String
   accounts: [data]

--- a/amplify/backend/function/teamRouter/src/index.py
+++ b/amplify/backend/function/teamRouter/src/index.py
@@ -57,10 +57,9 @@ def list_account_for_ou(ouId):
 
 
 def get_entitlements(id):
-    response = policy_table.get_item(
-        Key={
-            'id': id
-        }
+    response = policy_table.query(
+        IndexName="byEntityId",
+        KeyConditionExpression=boto3.dynamodb.conditions.Key('entityId').eq(id)
     )
     return response
 
@@ -79,24 +78,26 @@ def getEntitlements(userId, groupIds):
     for id in [userId] + groupIds:
         if not id:
             continue
-        entitlement = get_entitlements(id)
-        if "Item" not in entitlement.keys():
+        entitlements = get_entitlements(id)
+        if "Items" not in entitlements.keys():
             continue
-        duration = entitlement['Item']['duration']
-        if int(duration) > maxDuration:
-            maxDuration = int(duration)
-        policy = {}
-        policy['accounts'] = entitlement['Item']['accounts']
-        
-        for ou in entitlement["Item"]["ous"]:
-            data = list_account_for_ou(ou["id"])
-            policy['accounts'].extend(data)
+
+        for entitlement in entitlements["Items"]:    
+            duration = entitlement['duration']
+            if int(duration) > maxDuration:
+                maxDuration = int(duration)
+            policy = {}
+            policy['accounts'] = entitlement['accounts']
             
-        policy['permissions'] = entitlement['Item']['permissions']
-        policy['approvalRequired'] = entitlement['Item']['approvalRequired']
-        policy['duration'] = str(maxDuration)
-        
-        eligibility.append(policy)
+            for ou in entitlement["ous"]:
+                data = list_account_for_ou(ou["id"])
+                policy['accounts'].extend(data)
+                
+            policy['permissions'] = entitlement['permissions']
+            policy['approvalRequired'] = entitlement['approvalRequired']
+            policy['duration'] = str(maxDuration)
+            
+            eligibility.append(policy)
 
     return eligibility
 

--- a/amplify/backend/function/teamRouter/teamRouter-cloudformation-template.json
+++ b/amplify/backend/function/teamRouter/teamRouter-cloudformation-template.json
@@ -263,7 +263,8 @@
             {
               "Effect": "Allow",
               "Action": [
-                "dynamodb:GetItem"
+                "dynamodb:GetItem",
+                "dynamodb:Query"
               ],
               "Resource": [
                 {

--- a/amplify/backend/function/teamgetEntitlement/src/index.py
+++ b/amplify/backend/function/teamgetEntitlement/src/index.py
@@ -112,8 +112,7 @@ def handler(event, context):
     userId = event["userId"]
     groupIds = event["groupIds"]
     eligibility = []
-    maxDuration = 0
-    
+
     print("Id: ", event["id"])
 
     for id in [userId] + groupIds:
@@ -125,9 +124,6 @@ def handler(event, context):
             continue
         
         for entitlement in entitlements["Items"]:
-            duration = entitlement["duration"]
-            if int(duration) > maxDuration:
-                maxDuration = int(duration)
             policy = {}
             policy["accounts"] = entitlement["accounts"]
 
@@ -137,7 +133,7 @@ def handler(event, context):
 
             policy["permissions"] = entitlement["permissions"]
             policy["approvalRequired"] = entitlement["approvalRequired"]
-            policy["duration"] = str(maxDuration)
+            policy["duration"] = entitlement["duration"]
             eligibility.append(policy)
     result = {"id": event["id"], "policy": eligibility}
     print(result)

--- a/amplify/backend/function/teamgetEntitlement/teamgetEntitlement-cloudformation-template.json
+++ b/amplify/backend/function/teamgetEntitlement/teamgetEntitlement-cloudformation-template.json
@@ -186,7 +186,7 @@
             {
               "Effect": "Allow",
               "Action": [
-                "dynamodb:GetItem"
+                "dynamodb:Query"
               ],
               "Resource": [
                 {

--- a/src/components/Admin/Eligible.js
+++ b/src/components/Admin/Eligible.js
@@ -538,6 +538,7 @@ function Eligible(props) {
     validate(action).then((valid) => {
       if (valid) {
         event.preventDefault();
+        const uuidv4 = require("uuid/v4");
         resource.forEach((item) => {
           const data = {
             type: Type.value,
@@ -545,7 +546,8 @@ function Eligible(props) {
             accounts: account.map(({ value, label }) => ({name: label, id: value})),
             permissions: permission.map(({ value,label }) => ({name: label, id: value})),
             ous: ou.map(({ value,label }) => ({name: label, id: value})),
-            id: item.value,
+            id: uuidv4(),
+            entityId: item.value,
             ticketNo: ticketNo,
             approvalRequired: approvalRequired,
             duration: duration

--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -317,6 +317,7 @@ export const createEligibility = /* GraphQL */ `
   ) {
     createEligibility(input: $input, condition: $condition) {
       id
+      entityId
       name
       type
       accounts {

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -319,6 +319,7 @@ export const getEligibility = /* GraphQL */ `
   query GetEligibility($id: ID!) {
     getEligibility(id: $id) {
       id
+      entityId
       name
       type
       accounts {

--- a/src/models/schema.js
+++ b/src/models/schema.js
@@ -476,6 +476,13 @@ export const schema = {
                     "isRequired": true,
                     "attributes": []
                 },
+                "entityId": {
+                    "name": "entityId",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": true,
+                    "attributes": []
+                },
                 "name": {
                     "name": "name",
                     "isArray": false,


### PR DESCRIPTION
*Issue #, if available:* #39 #196

*Description of changes:*

Added the functionality to create multiple eligibility policies with the same group.

Technical changes:
V1.1.1: eligibility policies use the groupID as an unique identifier.
Unique identifier is now an uuidv4 instead of the groupID. The newly introduced entityID behaves now as the former unique identifier and references a group used by the eligibility policy.
This implementation is a **_breaking change_** as it does not migrate any eligibility policies of an existing deployment into the new data structure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
