### PR TITLE
Fix lambda runtime from 3.9 to python3.9

### DIFF
--- a/amplify/backend/function/teamgetMgmtAccountDetails/teamgetMgmtAccountDetails-cloudformation-template.json
+++ b/amplify/backend/function/teamgetMgmtAccountDetails/teamgetMgmtAccountDetails-cloudformation-template.json
@@ -78,7 +78,7 @@
             "Arn"
           ]
         },
-        "Runtime": "3.9",
+        "Runtime": "python3.9",
         "Layers": [],
         "Timeout": 25
       }


### PR DESCRIPTION
*Description of changes:*
Correct invalid Lambda runtime from `3.9` to `python3.9`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
