### PR TITLE
fix: comment optional UI_DOMAIN variable

### DIFF
--- a/deployment/parameters-template.sh
+++ b/deployment/parameters-template.sh
@@ -21,4 +21,6 @@ TEAM_ADMIN_GROUP="team_admin_group_name"
 TEAM_AUDITOR_GROUP="team_auditor_group_name"
 TAGS="project=iam-identity-center-team environment=prod"
 CLOUDTRAIL_AUDIT_LOGS=read_write
-UI_DOMAIN=portal.teamtest.online
+
+# Uncomment the next line only if you have a custom domain
+# UI_DOMAIN=portal.teamtest.online


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The parameter UI_DOMAIN is enabled by default in the parameters.sh. If the default value is left unchanged the installation fails. 
