### PR TITLE
Allow approval from both account an OU approvers

### DIFF
--- a/amplify/backend/function/teamRouter/src/index.py
+++ b/amplify/backend/function/teamRouter/src/index.py
@@ -394,20 +394,17 @@ def list_approvers(id):
         if "Item" in response.keys():
             return (response['Item']['groupIds'])
         else:
-            return None
+            return []
     except ClientError as e:
         print(e.response['Error']['Message'])
         
 def get_approver_group_ids(accountId):
-    try:
-        approvers = list_approvers(accountId)
-        if approvers:
-            return approvers
-        else:
-            ou = get_ou(accountId)
-            return(list_approvers(ou["Id"]))
-    except ClientError as e:
-        print("no approvers for account " + accountId)
+    approvers = []
+    approvers.extend(list_approvers(accountId))
+    ou = get_ou(accountId)
+    if ou:
+        approvers.extend(list_approvers(ou["Id"]))
+    return approvers
 
 def get_approvers(userId):
     client = boto3.client('identitystore')

--- a/src/components/Requests/Request.js
+++ b/src/components/Requests/Request.js
@@ -302,26 +302,26 @@ function Request(props) {
     const account_approvers = await fetchApprovers(account, "Account");
     if (account_approvers) {
       const data = await getGroupMemberships(account_approvers.groupIds);
-      if (
-        checkGroupMembership(props.groupIds, account_approvers.groupIds) &&
-        data.members.length < 2
-      ) {
-        return false;
-      } else if (data.members.length > 0) {
-        return account_approvers;
+      const requesterIsApprover = checkGroupMembership(props.groupIds, account_approvers.groupIds);
+      // If the requester is also an approver, then we need at least 2 approvers to exist (i.e. at
+      // least one person who didn't make the request). Otherwise we only need a single approver to exist.
+      const approverGroupMembersRequired = requesterIsApprover ? 2 : 1;
+
+      if (data.members.length >= approverGroupMembersRequired) {
+        return true;
       }
     }
     const ou = await fetchOU(account);
     const ou_approvers = await fetchApprovers(ou.Id, "OU");
     if (ou_approvers) {
       const data = await getGroupMemberships(ou_approvers.groupIds);
-      if (
-        checkGroupMembership(props.groupIds, ou_approvers.groupIds) &&
-        data.members.length < 2
-      ) {
-        return false;
-      } else if (data.members.length > 0) {
-        return ou_approvers;
+      const requesterIsApprover = checkGroupMembership(props.groupIds, ou_approvers.groupIds);
+      // If the requester is also an approver, then we need at least 2 approvers to exist (i.e. at
+      // least one person who didn't make the request). Otherwise we only need a single approver to exist.
+      const approverGroupMembersRequired = requesterIsApprover ? 2 : 1;
+
+      if (data.members.length >= approverGroupMembersRequired) {
+        return true;
       }
     }
     return false;


### PR DESCRIPTION
*Issue #, if available:*
#253

*Description of changes:*
This change allows approvers of both an Account and the parent OU to approve a request.

Previously the logic meant that if at least one approver group existed for an account then we'd immediately return that and not consider approvers of the parent OU. Now we build a list of both the accounts approvers groups and the OU approver groups.

I've also changed the error handling slightly, removing the try catch block in `get_approver_group_ids`, as the two functions we call (`get_ou` and `list_approvers` already catch and log a `ClientError` exception, so it's not possible for this exception to bubble up into `get_approver_group_ids`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
