### PR TITLE
Bypass approval if eligibility not requiring approval exists

### DIFF
--- a/amplify/backend/function/teamRouter/src/index.py
+++ b/amplify/backend/function/teamRouter/src/index.py
@@ -264,6 +264,8 @@ def eligibility_error(request):
     
 def get_eligibility(request, userId):
     eligible = False
+    # Initially assume approval is required
+    approvalRequired = True
     groupIds = [group['GroupId'] for group in list_idc_group_membership(userId)]
     entitlement = getEntitlements(userId=userId, groupIds=groupIds)
     print(entitlement)
@@ -275,14 +277,17 @@ def get_eligibility(request, userId):
             if request["accountId"] ==  account["id"]:
                 for permission in eligibility["permissions"]:
                     if request["roleId"] == permission["id"]:
-                        if eligibility["approvalRequired"]:
-                            return {"approval":True}
                         eligible = True
+                        # Only need a single eligibility to not require approval to
+                        # bypass approval for this request.
+                        if not eligibility["approvalRequired"]:
+                            approvalRequired = False
+
     if max_duration_error:
         print("Error - Invalid Duration")
         return eligibility_error(request) 
     if eligible:
-        return {"approval":False}   
+        return {"approval": approvalRequired}
     else:
         return eligibility_error(request)          
 

--- a/src/components/Requests/Request.js
+++ b/src/components/Requests/Request.js
@@ -271,20 +271,21 @@ function Request(props) {
   }
 
   async function checkApprovalNotRequired(account, role) {
+    let approvalNotRequired = false;
     for (const eligibility of item) {
       for (const acct of eligibility.accounts) {
         if (acct.id === account) {
           for (const perm of eligibility.permissions) {
             if (perm.id === role) {
-              if (eligibility.approvalRequired) {
-                return false;
+              if (!eligibility.approvalRequired) {
+                approvalNotRequired = true;
               }
             }
           }
         }
       }
     }
-    return true;
+    return approvalNotRequired;
   }
 
   function checkGroupMembership(groupIds, groupsIds) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change fixes an issue where approval for a request would be required, even if an eligibility exists for the account/role being requested that _didn't_ require approval. Take the following two eligibilities:

 - RO-Pre-Approved. Eligible to request RO permission set without approval required.
 - Admin-Approval-Required: Eligible to request AdministratorAccess and RO access, approval is required. (RO is included in this eligibility as we'd like someone who is a member of this group (and not necessarily a member of the first group!) to be able to access the RO role if it would be more suitable for the task they are performing. More generally, all of our eligibilities are named after the _most permissive_ role it gives access to, but they additionally include all roles that are less permissive.)

If someone is a member of both of these groups, we expect the behaviour to be:
 - They can request the RO role, and it does not require approval.
 - They can request AdministratorAccess, but approval is required.

With the current logic if an eligibility exists for a role that requires approval, approval will be required even if _another eligibility that doesn't require approval_ exists for that role.

This change updates the logic so we check all relevant eligibilities, and if any of them do not require approval then approval will not be required for the request. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
