### PR TITLE
Add retry mechanism to RevokeStateMachine to handle revocation failures

### DIFF
--- a/amplify/backend/custom/stepfunctions/stepfunctions-cloudformation-template.json
+++ b/amplify/backend/custom/stepfunctions/stepfunctions-cloudformation-template.json
@@ -605,6 +605,14 @@
               },
               "Resource": "arn:aws:states:::aws-sdk:ssoadmin:deleteAccountAssignment",
               "ResultPath": "$.revoke",
+              "Retry": [
+                {
+                  "ErrorEquals": ["ThrottlingException", "ServiceUnavailable", "InternalServerError"],
+                  "IntervalSeconds": 3,
+                  "BackoffRate": 2,
+                  "MaxAttempts": 5
+                }
+              ],
               "Type": "Task"
             },
             "Revoked || Ended ?": {


### PR DESCRIPTION
*Issue #, if available:* 327

*Description of changes: Add retry mechanism to RevokeStateMachine to handle revocation API call failures


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
