### PR TITLE
Add retry mechanism to GrantStateMachine to handle assignment failures

### DIFF
--- a/amplify/backend/custom/stepfunctions/stepfunctions-cloudformation-template.json
+++ b/amplify/backend/custom/stepfunctions/stepfunctions-cloudformation-template.json
@@ -84,6 +84,14 @@
               },
               "Resource": "arn:aws:states:::aws-sdk:ssoadmin:createAccountAssignment",
               "ResultPath": "$.grant",
+              "Retry": [
+                {
+                  "ErrorEquals": ["ThrottlingException", "ServiceUnavailable", "InternalServerError"],
+                  "IntervalSeconds": 3,
+                  "BackoffRate": 2,
+                  "MaxAttempts": 5
+                }
+              ],
               "Type": "Task"
             },
             "Notify Error": {


### PR DESCRIPTION
*Issue #, if available: #256*

*Description of changes:*
Similar to PR https://github.com/aws-samples/iam-identity-center-team/pull/346, add retry mechanism to account assignment to prevent failure due to throttling. The mentioned issue is already closed, however the issue still remains. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
