### PR TITLE
Slack Audit Notifications optional channel

### DIFF
--- a/amplify/backend/api/team/schema.graphql
+++ b/amplify/backend/api/team/schema.graphql
@@ -171,6 +171,7 @@ type Settings
   sesNotificationsEnabled: Boolean
   snsNotificationsEnabled: Boolean
   slackNotificationsEnabled: Boolean
+  slackAuditNotificationsChannel: String
   sesSourceEmail: String
   sesSourceArn: String
   slackToken: String

--- a/amplify/backend/function/teamNotifications/src/index.py
+++ b/amplify/backend/function/teamNotifications/src/index.py
@@ -11,22 +11,24 @@ from dateutil import parser, tz
 
 session = boto3.Session()
 
+
 def parse_arn(arn):
     # http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
-    elements = arn.split(':')
-    result = {'arn': elements[0],
-            'partition': elements[1],
-            'service': elements[2],
-            'region': elements[3],
-            'account': elements[4]
-           }
+    elements = arn.split(":")
+    result = {
+        "arn": elements[0],
+        "partition": elements[1],
+        "service": elements[2],
+        "region": elements[3],
+        "account": elements[4],
+    }
     if len(elements) == 7:
-        result['resourcetype'], result['resource'] = elements[5:]
-    elif '/' not in elements[5]:
-        result['resource'] = elements[5]
-        result['resourcetype'] = None
+        result["resourcetype"], result["resource"] = elements[5:]
+    elif "/" not in elements[5]:
+        result["resource"] = elements[5]
+        result["resourcetype"] = None
     else:
-        result['resourcetype'], result['resource'] = elements[5].split('/')
+        result["resourcetype"], result["resource"] = elements[5].split("/")
     return result
 
 
@@ -38,7 +40,7 @@ def send_ses_notification(
         if source_arn:
             ses_region = parse_arn(source_arn)["region"]
             ses_client = session.client("ses", region_name=ses_region)
-            
+
             ses_client.send_email(
                 Source=source_email,
                 SourceArn=source_arn,
@@ -49,8 +51,7 @@ def send_ses_notification(
                 },
             )
         else:
-            ses_client = session.client("ses"
-                                        )
+            ses_client = session.client("ses")
             ses_client.send_email(
                 Source=source_email,
                 Destination={"ToAddresses": to_addresses, "CcAddresses": cc_addresses},
@@ -78,6 +79,7 @@ def send_sns_notification(notification_topic_arn, message, subject):
 def send_slack_notifications(
     recipients,
     message,
+    audit_message,
     login_url,
     request_start_time,
     role,
@@ -93,6 +95,9 @@ def send_slack_notifications(
         settings = settings_table.get_item(Key={"id": "settings"})
         item_settings = settings.get("Item", {})
         slack_token = item_settings.get("slackToken", "")
+        slack_audit_notifications_channel = item_settings.get(
+            "slackAuditNotificationsChannel", ""
+        )
         if slack_token:
             slack_client = WebClient(token=slack_token)
     except Exception as error:
@@ -174,6 +179,62 @@ def send_slack_notifications(
                 f"Error posting chat message to channel/user id {recipient_slack_id}: {error}"
             )
 
+        # send audit notifications to channel if defined
+        if slack_audit_notifications_channel and audit_message:
+            try:
+                slack_client.chat_postMessage(
+                    channel=slack_audit_notifications_channel,
+                    text="AWS Access Request Audit Notification",
+                    blocks=[
+                        {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": f"*{audit_message}*",
+                            },
+                            "accessory": {
+                                "type": "button",
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": "Open TEAM",
+                                },
+                                "url": login_url,
+                                "action_id": "button-action",
+                            },
+                        },
+                        {
+                            "type": "section",
+                            "fields": [
+                                {
+                                    "type": "mrkdwn",
+                                    "text": f"*Account:*\n{account}",
+                                },
+                                {
+                                    "type": "mrkdwn",
+                                    "text": f"*Start time:*\n{formatted_date}",
+                                },
+                                {"type": "mrkdwn", "text": f"*Role:*\n{role}"},
+                                {
+                                    "type": "mrkdwn",
+                                    "text": f"*Duration:*\n{duration_hours} hours",
+                                },
+                                {
+                                    "type": "mrkdwn",
+                                    "text": f"*Justification:*\n{justification}",
+                                },
+                                {
+                                    "type": "mrkdwn",
+                                    "text": f"*Ticket Number:*\n{ticket}",
+                                },
+                            ],
+                        },
+                    ],
+                )
+            except Exception as error:
+                print(
+                    f"Error posting audit message to channel {slack_audit_notifications_channel} (ensure bot is invited to the channel): {error}"
+                )
+
 
 def lambda_handler(event: dict, context):
     ses_notifications_enabled = event.get("ses_notifications_enabled", "")
@@ -231,6 +292,7 @@ def lambda_handler(event: dict, context):
     ticket = event.get("ticketNo", "No ticket provided")
     login_url = event["sso_login_url"]
     sns_message = json.dumps(event)
+    slack_audit_message = ""
 
     match request_status:
         case "pending":
@@ -238,6 +300,9 @@ def lambda_handler(event: dict, context):
                 # Notify approvers pending request
                 slack_recipients = approvers
                 slack_message = f"<mailto:{requester}|{requester}> requests access to AWS, please approve or reject this request in TEAM."
+                slack_audit_message = (
+                    f"<mailto:{requester}|{requester}> has requested access to AWS"
+                )
                 email_to_addresses = approvers
                 email_cc_addresses = [requester]
                 subject = f"TEAM Access request to AWS account - {account}"
@@ -282,17 +347,17 @@ def lambda_handler(event: dict, context):
         case "approved":
             # Notify requester request approved
             slack_recipients = approvers + [requester]
-            slack_message = (
-                f"AWS access request was approved by {event['approver']}."
-            )
+            slack_message = f"AWS access request was approved by {event['approver']}."
             email_to_addresses = [requester]
             email_cc_addresses = approvers
             subject = f"AWS access request approved for {account} - TEAM"
+            slack_audit_message = f"AWS access request by <mailto:{requester}|{requester}> was approved by {event['approver']}"
             email_message_html = f'<html><body><p>Your AWS access request has been approved by {event["approver"]}. You will receive a notification when the session has started. Open <a href="{login_url}">TEAM</a> to manage AWS access requests.</p><p><b>Account:</b> {account}<br /><b>Role:</b> {role}<br /><b>Start Time:</b> {request_start_time}<br /><b>Duration:</b> {duration_hours} hours<br /><b>Justification:</b> {justification}<br /><b>Ticket Number:</b> {ticket}<br /></p></body></html>'
         case "rejected":
             # Notify requester request rejected
             slack_recipients = approvers + [requester]
             slack_message = "AWS access request was rejected."
+            slack_audit_message = f"AWS access request by <mailto:{requester}|{requester}> was rejected by {event['approver']}"
             email_to_addresses = [requester]
             email_cc_addresses = approvers
             subject = f"AWS access request rejected for {account} - TEAM"
@@ -304,6 +369,9 @@ def lambda_handler(event: dict, context):
             email_to_addresses = approvers
             email_cc_addresses = [requester]
             subject = f"AWS access request cancelled for {account} - TEAM"
+            slack_audit_message = (
+                f"AWS access request by <mailto:{requester}|{requester}> was cancelled"
+            )
             email_message_html = f'<html><body><p>{requester} cancelled an AWS access request. Open <a href="{login_url}">TEAM</a> to manage AWS access requests.</p><p><b>Account:</b> {account}<br /><b>Role:</b> {role}<br /><b>Start Time:</b> {request_start_time}<br /><b>Duration:</b> {duration_hours} hours<br /><b>Justification:</b> {justification}<br /><b>Ticket Number:</b> {ticket}<br /></p></body></html>'
         case "error":
             # Notify approvers and requester error
@@ -338,6 +406,7 @@ def lambda_handler(event: dict, context):
         send_slack_notifications(
             recipients=slack_recipients,
             message=slack_message,
+            audit_message=slack_audit_message,
             login_url=login_url,
             role=role,
             account=account,

--- a/src/components/Admin/Settings.js
+++ b/src/components/Admin/Settings.js
@@ -44,6 +44,7 @@ function Settings(props) {
     useState(null);
   const [slackToken, setSlackToken] = useState("");
   const [slackTokenError, setSlackTokenError] = useState("");
+  const [slackAuditNotificationsChannel, setSlackAuditNotificationsChannel] = useState(null);
   const [sesSourceEmail, setSesSourceEmail] = useState(null);
   const [sesSourceEmailError, setSesSourceEmailError] = useState("");
   const [sesSourceArn, setSesSourceArn] = useState(null);
@@ -175,7 +176,7 @@ function Settings(props) {
       setSnsNotificationsEnabled(item.snsNotificationsEnabled ?? false);
       setSlackNotificationsEnabled(item.slackNotificationsEnabled ?? false);
       setSesSourceEmail(item.sesSourceEmail ?? "");
-      setSesSourceArn(item.sesSourceArn ?? "" );
+      setSesSourceArn(item.sesSourceArn ?? "");
       setSlackToken(item.slackToken ?? "");
       setTeamAdminGroup(item.teamAdminGroup ?? params.teamAdminGroup);
       setTeamAuditorGroup(item.teamAuditorGroup ?? params.teamAuditorGroup);
@@ -195,6 +196,7 @@ function Settings(props) {
         sesNotificationsEnabled,
         snsNotificationsEnabled,
         slackNotificationsEnabled,
+        slackAuditNotificationsChannel,
         sesSourceEmail,
         sesSourceArn,
         slackToken,
@@ -227,8 +229,9 @@ function Settings(props) {
       setSesNotificationsEnabled(data?.sesNotificationsEnabled ?? false);
       setSnsNotificationsEnabled(data?.snsNotificationsEnabled ?? false);
       setSlackNotificationsEnabled(data?.slackNotificationsEnabled ?? false);
+      setSlackAuditNotificationsChannel(data?.slackAuditNotificationsChannel ?? "");
       setSesSourceEmail(data?.sesSourceEmail ?? "");
-      setSesSourceArn(data?.sesSourceArn ?? "" );
+      setSesSourceArn(data?.sesSourceArn ?? "");
       setSlackToken(data?.slackToken ?? "");
       setTeamAdminGroup(data?.teamAdminGroup ?? params.teamAdminGroup);
       setTeamAuditorGroup(data?.teamAuditorGroup ?? params.teamAuditorGroup);
@@ -461,6 +464,17 @@ function Settings(props) {
                   )}
                 </>
               </div>
+              {slackNotificationsEnabled === true && <div>
+                <Box variant="awsui-key-label">Slack Audit Channel</Box>
+                <>
+                  {" "}
+                  {slackAuditNotificationsChannel !== null ? (
+                    <div>{slackAuditNotificationsChannel || "<not set>"}</div>
+                  ) : (
+                    <Spinner />
+                  )}
+                </>
+              </div>}
             </SpaceBetween>
           </ColumnLayout>
         </Container>
@@ -731,6 +745,20 @@ function Settings(props) {
                       type="password"
                     >
                       Slack token
+                    </Input>
+                  </FormField>
+                  <FormField
+                    label="Slack Audit Channel"
+                    stretch
+                    description="(Optional) Channel to post notifications about all requests and approvals"
+                  >
+                    <Input value={slackAuditNotificationsChannel}
+                      onChange={(event) => {
+                        setSlackAuditNotificationsChannel(event.detail.value);
+                      }}
+                      type="text"
+                    >
+                      #channel-name
                     </Input>
                   </FormField>
                 </div>

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -272,6 +272,7 @@ export const getSettings = /* GraphQL */ `
       sesNotificationsEnabled
       snsNotificationsEnabled
       slackNotificationsEnabled
+      slackAuditNotificationsChannel
       sesSourceEmail
       sesSourceArn
       slackToken
@@ -301,6 +302,7 @@ export const listSettings = /* GraphQL */ `
         sesNotificationsEnabled
         snsNotificationsEnabled
         slackNotificationsEnabled
+        slackAuditNotificationsChannel
         sesSourceEmail
         sesSourceArn
         slackToken

--- a/src/models/index.d.ts
+++ b/src/models/index.d.ts
@@ -2,6 +2,20 @@ import { ModelInit, MutableModel } from "@aws-amplify/datastore";
 // @ts-ignore
 import { LazyLoading, LazyLoadingDisabled } from "@aws-amplify/datastore";
 
+type Eagerdata = {
+  readonly name?: string | null;
+  readonly id?: string | null;
+}
+
+type Lazydata = {
+  readonly name?: string | null;
+  readonly id?: string | null;
+}
+
+export declare type data = LazyLoading extends LazyLoadingDisabled ? Eagerdata : Lazydata
+
+export declare const data: (new (init: ModelInit<data>) => data)
+
 type EagerAccounts = {
   readonly name: string;
   readonly id: string;
@@ -16,63 +30,23 @@ export declare type Accounts = LazyLoading extends LazyLoadingDisabled ? EagerAc
 
 export declare const Accounts: (new (init: ModelInit<Accounts>) => Accounts)
 
-type EagerOUs = {
-  readonly Id: string;
-  readonly Arn: string;
-  readonly Name: string;
+type EagerEntitlement = {
+  readonly accounts?: (data | null)[] | null;
+  readonly permissions?: (data | null)[] | null;
+  readonly approvalRequired?: boolean | null;
+  readonly duration?: string | null;
 }
 
-type LazyOUs = {
-  readonly Id: string;
-  readonly Arn: string;
-  readonly Name: string;
+type LazyEntitlement = {
+  readonly accounts?: (data | null)[] | null;
+  readonly permissions?: (data | null)[] | null;
+  readonly approvalRequired?: boolean | null;
+  readonly duration?: string | null;
 }
 
-export declare type OUs = LazyLoading extends LazyLoadingDisabled ? EagerOUs : LazyOUs
+export declare type Entitlement = LazyLoading extends LazyLoadingDisabled ? EagerEntitlement : LazyEntitlement
 
-export declare const OUs: (new (init: ModelInit<OUs>) => OUs)
-
-type EagerOU = {
-  readonly Id: string;
-}
-
-type LazyOU = {
-  readonly Id: string;
-}
-
-export declare type OU = LazyLoading extends LazyLoadingDisabled ? EagerOU : LazyOU
-
-export declare const OU: (new (init: ModelInit<OU>) => OU)
-
-type EagerPermissions = {
-  readonly Name: string;
-  readonly Arn: string;
-}
-
-type LazyPermissions = {
-  readonly Name: string;
-  readonly Arn: string;
-}
-
-export declare type Permissions = LazyLoading extends LazyLoadingDisabled ? EagerPermissions : LazyPermissions
-
-export declare const Permissions: (new (init: ModelInit<Permissions>) => Permissions)
-
-type EagerGroups = {
-  readonly groups?: (string | null)[] | null;
-  readonly userId?: string | null;
-  readonly groupIds?: (string | null)[] | null;
-}
-
-type LazyGroups = {
-  readonly groups?: (string | null)[] | null;
-  readonly userId?: string | null;
-  readonly groupIds?: (string | null)[] | null;
-}
-
-export declare type Groups = LazyLoading extends LazyLoadingDisabled ? EagerGroups : LazyGroups
-
-export declare const Groups: (new (init: ModelInit<Groups>) => Groups)
+export declare const Entitlement: (new (init: ModelInit<Entitlement>) => Entitlement)
 
 type EagerIdCGroups = {
   readonly GroupId: string;
@@ -120,33 +94,33 @@ export declare type Logs = LazyLoading extends LazyLoadingDisabled ? EagerLogs :
 
 export declare const Logs: (new (init: ModelInit<Logs>) => Logs)
 
-type EagerEntitlement = {
-  readonly accounts?: (data | null)[] | null;
-  readonly permissions?: (data | null)[] | null;
+type EagerOU = {
+  readonly Id: string;
 }
 
-type LazyEntitlement = {
-  readonly accounts?: (data | null)[] | null;
-  readonly permissions?: (data | null)[] | null;
+type LazyOU = {
+  readonly Id: string;
 }
 
-export declare type Entitlement = LazyLoading extends LazyLoadingDisabled ? EagerEntitlement : LazyEntitlement
+export declare type OU = LazyLoading extends LazyLoadingDisabled ? EagerOU : LazyOU
 
-export declare const Entitlement: (new (init: ModelInit<Entitlement>) => Entitlement)
+export declare const OU: (new (init: ModelInit<OU>) => OU)
 
-type Eagerdata = {
-  readonly name?: string | null;
-  readonly id?: string | null;
+type EagerGroups = {
+  readonly groups?: (string | null)[] | null;
+  readonly userId?: string | null;
+  readonly groupIds?: (string | null)[] | null;
 }
 
-type Lazydata = {
-  readonly name?: string | null;
-  readonly id?: string | null;
+type LazyGroups = {
+  readonly groups?: (string | null)[] | null;
+  readonly userId?: string | null;
+  readonly groupIds?: (string | null)[] | null;
 }
 
-export declare type data = LazyLoading extends LazyLoadingDisabled ? Eagerdata : Lazydata
+export declare type Groups = LazyLoading extends LazyLoadingDisabled ? EagerGroups : LazyGroups
 
-export declare const data: (new (init: ModelInit<data>) => data)
+export declare const Groups: (new (init: ModelInit<Groups>) => Groups)
 
 type EagerMembers = {
   readonly members?: (string | null)[] | null;
@@ -160,6 +134,74 @@ export declare type Members = LazyLoading extends LazyLoadingDisabled ? EagerMem
 
 export declare const Members: (new (init: ModelInit<Members>) => Members)
 
+type EagerPermissions = {
+  readonly Name: string;
+  readonly Arn: string;
+  readonly Duration?: string | null;
+}
+
+type LazyPermissions = {
+  readonly Name: string;
+  readonly Arn: string;
+  readonly Duration?: string | null;
+}
+
+export declare type Permissions = LazyLoading extends LazyLoadingDisabled ? EagerPermissions : LazyPermissions
+
+export declare const Permissions: (new (init: ModelInit<Permissions>) => Permissions)
+
+type EagerMgmtPs = {
+  readonly permissions?: (string | null)[] | null;
+}
+
+type LazyMgmtPs = {
+  readonly permissions?: (string | null)[] | null;
+}
+
+export declare type MgmtPs = LazyLoading extends LazyLoadingDisabled ? EagerMgmtPs : LazyMgmtPs
+
+export declare const MgmtPs: (new (init: ModelInit<MgmtPs>) => MgmtPs)
+
+type EagerPolicy = {
+  readonly id: string;
+  readonly policy?: (Entitlement | null)[] | null;
+}
+
+type LazyPolicy = {
+  readonly id: string;
+  readonly policy?: (Entitlement | null)[] | null;
+}
+
+export declare type Policy = LazyLoading extends LazyLoadingDisabled ? EagerPolicy : LazyPolicy
+
+export declare const Policy: (new (init: ModelInit<Policy>) => Policy)
+
+type EagerOUs = {
+  readonly ous?: string | null;
+}
+
+type LazyOUs = {
+  readonly ous?: string | null;
+}
+
+export declare type OUs = LazyLoading extends LazyLoadingDisabled ? EagerOUs : LazyOUs
+
+export declare const OUs: (new (init: ModelInit<OUs>) => OUs)
+
+type EagerPermission = {
+  readonly id: string;
+  readonly permissions?: (Permissions | null)[] | null;
+}
+
+type LazyPermission = {
+  readonly id: string;
+  readonly permissions?: (Permissions | null)[] | null;
+}
+
+export declare type Permission = LazyLoading extends LazyLoadingDisabled ? EagerPermission : LazyPermission
+
+export declare const Permission: (new (init: ModelInit<Permission>) => Permission)
+
 type requestsMetaData = {
   readOnlyFields: 'createdAt' | 'updatedAt';
 }
@@ -169,6 +211,10 @@ type sessionsMetaData = {
 }
 
 type ApproversMetaData = {
+  readOnlyFields: 'createdAt' | 'updatedAt';
+}
+
+type SettingsMetaData = {
   readOnlyFields: 'createdAt' | 'updatedAt';
 }
 
@@ -188,13 +234,17 @@ type Eagerrequests = {
   readonly justification?: string | null;
   readonly status?: string | null;
   readonly comment?: string | null;
+  readonly username?: string | null;
   readonly approver?: string | null;
+  readonly approverId?: string | null;
   readonly approvers?: (string | null)[] | null;
   readonly approver_ids?: (string | null)[] | null;
   readonly revoker?: string | null;
+  readonly revokerId?: string | null;
   readonly endTime?: string | null;
   readonly ticketNo?: string | null;
   readonly revokeComment?: string | null;
+  readonly session_duration?: string | null;
   readonly createdAt?: string | null;
   readonly updatedAt?: string | null;
 }
@@ -211,13 +261,17 @@ type Lazyrequests = {
   readonly justification?: string | null;
   readonly status?: string | null;
   readonly comment?: string | null;
+  readonly username?: string | null;
   readonly approver?: string | null;
+  readonly approverId?: string | null;
   readonly approvers?: (string | null)[] | null;
   readonly approver_ids?: (string | null)[] | null;
   readonly revoker?: string | null;
+  readonly revokerId?: string | null;
   readonly endTime?: string | null;
   readonly ticketNo?: string | null;
   readonly revokeComment?: string | null;
+  readonly session_duration?: string | null;
   readonly createdAt?: string | null;
   readonly updatedAt?: string | null;
 }
@@ -237,6 +291,7 @@ type Eagersessions = {
   readonly role?: string | null;
   readonly approver_ids?: (string | null)[] | null;
   readonly queryId?: string | null;
+  readonly expireAt?: number | null;
   readonly createdAt?: string | null;
   readonly updatedAt?: string | null;
 }
@@ -250,6 +305,7 @@ type Lazysessions = {
   readonly role?: string | null;
   readonly approver_ids?: (string | null)[] | null;
   readonly queryId?: string | null;
+  readonly expireAt?: number | null;
   readonly createdAt?: string | null;
   readonly updatedAt?: string | null;
 }
@@ -267,6 +323,7 @@ type EagerApprovers = {
   readonly approvers?: (string | null)[] | null;
   readonly groupIds?: (string | null)[] | null;
   readonly ticketNo?: string | null;
+  readonly modifiedBy?: string | null;
   readonly createdAt?: string | null;
   readonly updatedAt?: string | null;
 }
@@ -278,6 +335,7 @@ type LazyApprovers = {
   readonly approvers?: (string | null)[] | null;
   readonly groupIds?: (string | null)[] | null;
   readonly ticketNo?: string | null;
+  readonly modifiedBy?: string | null;
   readonly createdAt?: string | null;
   readonly updatedAt?: string | null;
 }
@@ -288,6 +346,54 @@ export declare const Approvers: (new (init: ModelInit<Approvers, ApproversMetaDa
   copyOf(source: Approvers, mutator: (draft: MutableModel<Approvers, ApproversMetaData>) => MutableModel<Approvers, ApproversMetaData> | void): Approvers;
 }
 
+type EagerSettings = {
+  readonly id: string;
+  readonly duration?: string | null;
+  readonly expiry?: string | null;
+  readonly comments?: boolean | null;
+  readonly ticketNo?: boolean | null;
+  readonly approval?: boolean | null;
+  readonly modifiedBy?: string | null;
+  readonly sesNotificationsEnabled?: boolean | null;
+  readonly snsNotificationsEnabled?: boolean | null;
+  readonly slackNotificationsEnabled?: boolean | null;
+  readonly slackAuditNotificationsChannel?: string | null;
+  readonly sesSourceEmail?: string | null;
+  readonly sesSourceArn?: string | null;
+  readonly slackToken?: string | null;
+  readonly teamAdminGroup?: string | null;
+  readonly teamAuditorGroup?: string | null;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+}
+
+type LazySettings = {
+  readonly id: string;
+  readonly duration?: string | null;
+  readonly expiry?: string | null;
+  readonly comments?: boolean | null;
+  readonly ticketNo?: boolean | null;
+  readonly approval?: boolean | null;
+  readonly modifiedBy?: string | null;
+  readonly sesNotificationsEnabled?: boolean | null;
+  readonly snsNotificationsEnabled?: boolean | null;
+  readonly slackNotificationsEnabled?: boolean | null;
+  readonly slackAuditNotificationsChannel?: string | null;
+  readonly sesSourceEmail?: string | null;
+  readonly sesSourceArn?: string | null;
+  readonly slackToken?: string | null;
+  readonly teamAdminGroup?: string | null;
+  readonly teamAuditorGroup?: string | null;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+}
+
+export declare type Settings = LazyLoading extends LazyLoadingDisabled ? EagerSettings : LazySettings
+
+export declare const Settings: (new (init: ModelInit<Settings, SettingsMetaData>) => Settings) & {
+  copyOf(source: Settings, mutator: (draft: MutableModel<Settings, SettingsMetaData>) => MutableModel<Settings, SettingsMetaData> | void): Settings;
+}
+
 type EagerEligibility = {
   readonly id: string;
   readonly name?: string | null;
@@ -296,6 +402,9 @@ type EagerEligibility = {
   readonly ous?: (data | null)[] | null;
   readonly permissions?: (data | null)[] | null;
   readonly ticketNo?: string | null;
+  readonly approvalRequired?: boolean | null;
+  readonly duration?: string | null;
+  readonly modifiedBy?: string | null;
   readonly createdAt?: string | null;
   readonly updatedAt?: string | null;
 }
@@ -308,6 +417,9 @@ type LazyEligibility = {
   readonly ous?: (data | null)[] | null;
   readonly permissions?: (data | null)[] | null;
   readonly ticketNo?: string | null;
+  readonly approvalRequired?: boolean | null;
+  readonly duration?: string | null;
+  readonly modifiedBy?: string | null;
   readonly createdAt?: string | null;
   readonly updatedAt?: string | null;
 }

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -4,22 +4,26 @@ import { schema } from './schema';
 
 
 
-const { requests, sessions, Approvers, Eligibility, Accounts, OUs, OU, Permissions, Groups, IdCGroups, Users, Logs, Entitlement, data, Members } = initSchema(schema);
+const { requests, sessions, Approvers, Settings, Eligibility, data, Accounts, Entitlement, IdCGroups, Users, Logs, OU, Groups, Members, Permissions, MgmtPs, Policy, OUs, Permission } = initSchema(schema);
 
 export {
   requests,
   sessions,
   Approvers,
+  Settings,
   Eligibility,
+  data,
   Accounts,
-  OUs,
-  OU,
-  Permissions,
-  Groups,
+  Entitlement,
   IdCGroups,
   Users,
   Logs,
-  Entitlement,
-  data,
-  Members
+  OU,
+  Groups,
+  Members,
+  Permissions,
+  MgmtPs,
+  Policy,
+  OUs,
+  Permission
 };

--- a/src/models/schema.js
+++ b/src/models/schema.js
@@ -80,8 +80,22 @@ export const schema = {
                     "isRequired": false,
                     "attributes": []
                 },
+                "username": {
+                    "name": "username",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
                 "approver": {
                     "name": "approver",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "approverId": {
+                    "name": "approverId",
                     "isArray": false,
                     "type": "String",
                     "isRequired": false,
@@ -110,6 +124,13 @@ export const schema = {
                     "isRequired": false,
                     "attributes": []
                 },
+                "revokerId": {
+                    "name": "revokerId",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
                 "endTime": {
                     "name": "endTime",
                     "isArray": false,
@@ -126,6 +147,13 @@ export const schema = {
                 },
                 "revokeComment": {
                     "name": "revokeComment",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "session_duration": {
+                    "name": "session_duration",
                     "isArray": false,
                     "type": "String",
                     "isRequired": false,
@@ -176,7 +204,7 @@ export const schema = {
                         "name": "byApproverAndStatus",
                         "queryField": "requestByApproverAndStatus",
                         "fields": [
-                            "approver",
+                            "approverId",
                             "status"
                         ]
                     }
@@ -200,23 +228,28 @@ export const schema = {
                                 "provider": "userPools",
                                 "ownerField": "owner",
                                 "allow": "owner",
-                                "identityClaim": "cognito:username",
                                 "operations": [
                                     "create",
-                                    "update",
-                                    "delete",
                                     "read"
-                                ]
+                                ],
+                                "identityClaim": "cognito:username"
                             },
                             {
                                 "provider": "userPools",
                                 "ownerField": "approver_ids",
                                 "allow": "owner",
                                 "operations": [
-                                    "update",
                                     "read"
                                 ],
                                 "identityClaim": "cognito:username"
+                            },
+                            {
+                                "allow": "private",
+                                "provider": "iam",
+                                "operations": [
+                                    "read",
+                                    "update"
+                                ]
                             }
                         ]
                     }
@@ -229,7 +262,7 @@ export const schema = {
                 "id": {
                     "name": "id",
                     "isArray": false,
-                    "type": "ID",
+                    "type": "String",
                     "isRequired": true,
                     "attributes": []
                 },
@@ -283,6 +316,13 @@ export const schema = {
                     "isRequired": false,
                     "attributes": []
                 },
+                "expireAt": {
+                    "name": "expireAt",
+                    "isArray": false,
+                    "type": "AWSTimestamp",
+                    "isRequired": false,
+                    "attributes": []
+                },
                 "createdAt": {
                     "name": "createdAt",
                     "isArray": false,
@@ -332,6 +372,18 @@ export const schema = {
                             {
                                 "provider": "userPools",
                                 "ownerField": "owner",
+                                "allow": "owner",
+                                "identityClaim": "cognito:username",
+                                "operations": [
+                                    "create",
+                                    "update",
+                                    "delete",
+                                    "read"
+                                ]
+                            },
+                            {
+                                "provider": "userPools",
+                                "ownerField": "username",
                                 "allow": "owner",
                                 "identityClaim": "cognito:username",
                                 "operations": [
@@ -413,6 +465,13 @@ export const schema = {
                     "isRequired": false,
                     "attributes": []
                 },
+                "modifiedBy": {
+                    "name": "modifiedBy",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
                 "createdAt": {
                     "name": "createdAt",
                     "isArray": false,
@@ -447,6 +506,210 @@ export const schema = {
                                 "allow": "groups",
                                 "groups": [
                                     "Admin"
+                                ],
+                                "operations": [
+                                    "create",
+                                    "update",
+                                    "delete",
+                                    "read"
+                                ]
+                            },
+                            {
+                                "groupClaim": "scope",
+                                "provider": "userPools",
+                                "allow": "groups",
+                                "groups": [
+                                    "api/admin"
+                                ],
+                                "operations": [
+                                    "create",
+                                    "update",
+                                    "delete",
+                                    "read"
+                                ]
+                            },
+                            {
+                                "allow": "private",
+                                "operations": [
+                                    "read"
+                                ]
+                            },
+                            {
+                                "allow": "private",
+                                "provider": "iam",
+                                "operations": [
+                                    "read",
+                                    "update"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "Settings": {
+            "name": "Settings",
+            "fields": {
+                "id": {
+                    "name": "id",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "duration": {
+                    "name": "duration",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "expiry": {
+                    "name": "expiry",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "comments": {
+                    "name": "comments",
+                    "isArray": false,
+                    "type": "Boolean",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "ticketNo": {
+                    "name": "ticketNo",
+                    "isArray": false,
+                    "type": "Boolean",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "approval": {
+                    "name": "approval",
+                    "isArray": false,
+                    "type": "Boolean",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "modifiedBy": {
+                    "name": "modifiedBy",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "sesNotificationsEnabled": {
+                    "name": "sesNotificationsEnabled",
+                    "isArray": false,
+                    "type": "Boolean",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "snsNotificationsEnabled": {
+                    "name": "snsNotificationsEnabled",
+                    "isArray": false,
+                    "type": "Boolean",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "slackNotificationsEnabled": {
+                    "name": "slackNotificationsEnabled",
+                    "isArray": false,
+                    "type": "Boolean",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "slackAuditNotificationsChannel": {
+                    "name": "slackAuditNotificationsChannel",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "sesSourceEmail": {
+                    "name": "sesSourceEmail",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "sesSourceArn": {
+                    "name": "sesSourceArn",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "slackToken": {
+                    "name": "slackToken",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "teamAdminGroup": {
+                    "name": "teamAdminGroup",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "teamAuditorGroup": {
+                    "name": "teamAuditorGroup",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                },
+                "updatedAt": {
+                    "name": "updatedAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isReadOnly": true
+                }
+            },
+            "syncable": true,
+            "pluralName": "Settings",
+            "attributes": [
+                {
+                    "type": "model",
+                    "properties": {}
+                },
+                {
+                    "type": "auth",
+                    "properties": {
+                        "rules": [
+                            {
+                                "groupClaim": "cognito:groups",
+                                "provider": "userPools",
+                                "allow": "groups",
+                                "groups": [
+                                    "Admin"
+                                ],
+                                "operations": [
+                                    "create",
+                                    "update",
+                                    "delete",
+                                    "read"
+                                ]
+                            },
+                            {
+                                "groupClaim": "scope",
+                                "provider": "userPools",
+                                "allow": "groups",
+                                "groups": [
+                                    "api/admin"
                                 ],
                                 "operations": [
                                     "create",
@@ -527,6 +790,27 @@ export const schema = {
                     "isRequired": false,
                     "attributes": []
                 },
+                "approvalRequired": {
+                    "name": "approvalRequired",
+                    "isArray": false,
+                    "type": "Boolean",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "duration": {
+                    "name": "duration",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "modifiedBy": {
+                    "name": "modifiedBy",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
                 "createdAt": {
                     "name": "createdAt",
                     "isArray": false,
@@ -570,9 +854,31 @@ export const schema = {
                                 ]
                             },
                             {
+                                "groupClaim": "scope",
+                                "provider": "userPools",
+                                "allow": "groups",
+                                "groups": [
+                                    "api/admin"
+                                ],
+                                "operations": [
+                                    "create",
+                                    "update",
+                                    "delete",
+                                    "read"
+                                ]
+                            },
+                            {
                                 "allow": "private",
                                 "operations": [
                                     "read"
+                                ]
+                            },
+                            {
+                                "allow": "private",
+                                "provider": "iam",
+                                "operations": [
+                                    "read",
+                                    "update"
                                 ]
                             }
                         ]
@@ -583,6 +889,25 @@ export const schema = {
     },
     "enums": {},
     "nonModels": {
+        "data": {
+            "name": "data",
+            "fields": {
+                "name": {
+                    "name": "name",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "id": {
+                    "name": "id",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                }
+            }
+        },
         "Accounts": {
             "name": "Accounts",
             "fields": {
@@ -602,88 +927,42 @@ export const schema = {
                 }
             }
         },
-        "OUs": {
-            "name": "OUs",
+        "Entitlement": {
+            "name": "Entitlement",
             "fields": {
-                "Id": {
-                    "name": "Id",
-                    "isArray": false,
-                    "type": "String",
-                    "isRequired": true,
-                    "attributes": []
-                },
-                "Arn": {
-                    "name": "Arn",
-                    "isArray": false,
-                    "type": "String",
-                    "isRequired": true,
-                    "attributes": []
-                },
-                "Name": {
-                    "name": "Name",
-                    "isArray": false,
-                    "type": "String",
-                    "isRequired": true,
-                    "attributes": []
-                }
-            }
-        },
-        "OU": {
-            "name": "OU",
-            "fields": {
-                "Id": {
-                    "name": "Id",
-                    "isArray": false,
-                    "type": "String",
-                    "isRequired": true,
-                    "attributes": []
-                }
-            }
-        },
-        "Permissions": {
-            "name": "Permissions",
-            "fields": {
-                "Name": {
-                    "name": "Name",
-                    "isArray": false,
-                    "type": "String",
-                    "isRequired": true,
-                    "attributes": []
-                },
-                "Arn": {
-                    "name": "Arn",
-                    "isArray": false,
-                    "type": "String",
-                    "isRequired": true,
-                    "attributes": []
-                }
-            }
-        },
-        "Groups": {
-            "name": "Groups",
-            "fields": {
-                "groups": {
-                    "name": "groups",
+                "accounts": {
+                    "name": "accounts",
                     "isArray": true,
-                    "type": "String",
+                    "type": {
+                        "nonModel": "data"
+                    },
                     "isRequired": false,
                     "attributes": [],
                     "isArrayNullable": true
                 },
-                "userId": {
-                    "name": "userId",
+                "permissions": {
+                    "name": "permissions",
+                    "isArray": true,
+                    "type": {
+                        "nonModel": "data"
+                    },
+                    "isRequired": false,
+                    "attributes": [],
+                    "isArrayNullable": true
+                },
+                "approvalRequired": {
+                    "name": "approvalRequired",
+                    "isArray": false,
+                    "type": "Boolean",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "duration": {
+                    "name": "duration",
                     "isArray": false,
                     "type": "String",
                     "isRequired": false,
                     "attributes": []
-                },
-                "groupIds": {
-                    "name": "groupIds",
-                    "isArray": true,
-                    "type": "String",
-                    "isRequired": false,
-                    "attributes": [],
-                    "isArrayNullable": true
                 }
             }
         },
@@ -758,47 +1037,43 @@ export const schema = {
                 }
             }
         },
-        "Entitlement": {
-            "name": "Entitlement",
+        "OU": {
+            "name": "OU",
             "fields": {
-                "accounts": {
-                    "name": "accounts",
-                    "isArray": true,
-                    "type": {
-                        "nonModel": "data"
-                    },
-                    "isRequired": false,
-                    "attributes": [],
-                    "isArrayNullable": true
-                },
-                "permissions": {
-                    "name": "permissions",
-                    "isArray": true,
-                    "type": {
-                        "nonModel": "data"
-                    },
-                    "isRequired": false,
-                    "attributes": [],
-                    "isArrayNullable": true
+                "Id": {
+                    "name": "Id",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": true,
+                    "attributes": []
                 }
             }
         },
-        "data": {
-            "name": "data",
+        "Groups": {
+            "name": "Groups",
             "fields": {
-                "name": {
-                    "name": "name",
+                "groups": {
+                    "name": "groups",
+                    "isArray": true,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isArrayNullable": true
+                },
+                "userId": {
+                    "name": "userId",
                     "isArray": false,
                     "type": "String",
                     "isRequired": false,
                     "attributes": []
                 },
-                "id": {
-                    "name": "id",
-                    "isArray": false,
+                "groupIds": {
+                    "name": "groupIds",
+                    "isArray": true,
                     "type": "String",
                     "isRequired": false,
-                    "attributes": []
+                    "attributes": [],
+                    "isArrayNullable": true
                 }
             }
         },
@@ -814,8 +1089,103 @@ export const schema = {
                     "isArrayNullable": true
                 }
             }
+        },
+        "Permissions": {
+            "name": "Permissions",
+            "fields": {
+                "Name": {
+                    "name": "Name",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "Arn": {
+                    "name": "Arn",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "Duration": {
+                    "name": "Duration",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                }
+            }
+        },
+        "MgmtPs": {
+            "name": "MgmtPs",
+            "fields": {
+                "permissions": {
+                    "name": "permissions",
+                    "isArray": true,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isArrayNullable": true
+                }
+            }
+        },
+        "Policy": {
+            "name": "Policy",
+            "fields": {
+                "id": {
+                    "name": "id",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "policy": {
+                    "name": "policy",
+                    "isArray": true,
+                    "type": {
+                        "nonModel": "Entitlement"
+                    },
+                    "isRequired": false,
+                    "attributes": [],
+                    "isArrayNullable": true
+                }
+            }
+        },
+        "OUs": {
+            "name": "OUs",
+            "fields": {
+                "ous": {
+                    "name": "ous",
+                    "isArray": false,
+                    "type": "AWSJSON",
+                    "isRequired": false,
+                    "attributes": []
+                }
+            }
+        },
+        "Permission": {
+            "name": "Permission",
+            "fields": {
+                "id": {
+                    "name": "id",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "permissions": {
+                    "name": "permissions",
+                    "isArray": true,
+                    "type": {
+                        "nonModel": "Permissions"
+                    },
+                    "isRequired": false,
+                    "attributes": [],
+                    "isArrayNullable": true
+                }
+            }
         }
     },
-    "codegenVersion": "3.3.1",
-    "version": "adee63136a5ec7298cb70dc572353349"
+    "codegenVersion": "3.4.4",
+    "version": "fc07e42e84b950bb45581d50e1b5438e"
 };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This simple change allows the administrator to (optionally) configure a Slack channel to send notifications about activity in the TEAM app, notably:
* Requests
* Approvals
* Rejections

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
