### PR TITLE
fix: User revoke own session

### DIFF
--- a/amplify/backend/api/team/schema.graphql
+++ b/amplify/backend/api/team/schema.graphql
@@ -95,7 +95,7 @@ type requests
   @auth(
     rules: [
       { allow: groups, groups: ["Auditors"], operations: [read] }
-      { allow: owner, operations: [read]}
+      { allow: owner, operations: [read, update]}
       { allow: owner, ownerField: "approver_ids", operations: [update,read] }
       { allow: private, provider: iam, operations: [read, update] }
     ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix issue with a user being able to revoke their own session. Added 'update' permissions to owners for the 'revokerId' field.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
