### PR TITLE
Docs: Update Terraform Provider link and Improve documentation visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Visit our **[Documentation pages](https://aws-samples.github.io/iam-identity-cen
 - [Blog Post](https://aws.amazon.com/blogs/security/temporary-elevated-access-management-with-iam-identity-center/)
 - [ReInforce talk](https://www.youtube.com/watch?v=a1Na2G7TTQ0)
 - [Feedback form](https://www.pulse.aws/survey/PZDTVK85)
+- Explore the community-supported [Terraform provider designed for awsteam](https://registry.terraform.io/providers/awsteam-contrib/awsteam/latest)
 
 ## Feedback 
 

--- a/docs/docs/deployment/configuration/cognito_machine_auth.md
+++ b/docs/docs/deployment/configuration/cognito_machine_auth.md
@@ -61,10 +61,3 @@ In order to use machine authentication on the Graph API, you need:
 1. Obtain the client Id and Secret from the Cognito User Pool Client named `machine_auth` or using the **get-machine-auth-credentials.sh** script.
 2. Use these to obtain a token from the token endpoint for the Cognito User Pool. This process is detailed in the [AWS Cognito Guide](https://docs.aws.amazon.com/cognito/latest/developerguide/token-endpoint.html).
 3. Use this token in the `Authorization` header when making calls to the TEAM Graph API. 
-
-### Using the Terraform Provider
-
-Explore the community-supported [Terraform provider designed for awsteam](https://registry.terraform.io/providers/brittandeyoung/awsteam/latest), enabling seamless configuration management through Terraform. Machine authentication credentials are required to use the provider.
-
-> The Terraform provider is maintained independently of the aws-samples community, and the TEAM authors do not assume responsibility for its maintenance.
-{: .important}

--- a/docs/docs/deployment/configuration/terraform.md
+++ b/docs/docs/deployment/configuration/terraform.md
@@ -1,0 +1,20 @@
+---
+layout: default
+title: Terraform
+nav_order: 8
+parent: Configuration
+grand_parent: Solution deployment
+---
+
+# IAM Identity Center Configuration with Terraform
+
+You must perform the following configuration steps to start configuring TEAM using Terraform:
+1. [Configuration Prerequisites]({% link docs/deployment/configuration/index.md %})
+2. [Configure Cognito Machine Authentication]({% link docs/deployment/configuration/cognito_machine_auth.md %})
+
+### Using the Terraform Provider
+
+Explore the community-supported [Terraform provider designed for awsteam](https://registry.terraform.io/providers/awsteam-contrib/awsteam/latest), enabling seamless configuration management through Terraform. Machine authentication credentials are required to use the provider.
+
+> The Terraform provider is maintained independently of the aws-samples community, and the TEAM authors do not assume responsibility for its maintenance.
+{: .important}


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*
The community maintained provider has been moved to a new GitHub organization. This PR intends to update the links for the provider and help make the provider more discoverable. (Existing link still works, as Github performs needed redirects).


This pull requests includes the following:

1. Moves the documentation for the Terraform Provider to its own docs page.
2. Updates the URL for the Provider Registry as the provider has been moved to a new GitHub Organization. 
3. Adds a Quick Link to the community-supported Terraform Provider  to improve visability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
