### PR TITLE
Clarify update process documentation with CloudFormation deployment step

### DIFF
--- a/docs/docs/deployment/update.md
+++ b/docs/docs/deployment/update.md
@@ -16,7 +16,8 @@ The **update.sh** bash script performs the following actions:
 
 - Adds the AWS samples github repo as a git remote
 - Pulls the latest version of the TEAM code
-- Push the latest version to the TEAM code commit repo which triggers the amplify build and deployment 
+- Push the latest version to the TEAM code commit repo
+- Deploys an AWS CloudFormation stack which triggers the amplify build and deployment
 - Removes the AWS samples github repo as a git remote
 
   > Ensure that the named profile for the **TEAM Deployment account** has sufficient permissions before executing the **update.sh** script


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Minor change to documentation to clarify that the update.sh script deploys a cloudformation template, as this was not made clear in the previous documentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
