### PR TITLE
fix: display dash instead of unix epoch start time for a session that…

### DIFF
--- a/src/components/Audit/AuditSessions.js
+++ b/src/components/Audit/AuditSessions.js
@@ -441,7 +441,7 @@ function AuditSessions(props) {
                   />
                   <ValueWithLabel
                     label="End Time"
-                    children={convertAwsDateTime(selectedItems[0].endTime)}
+                    children={selectedItems[0].endTime ? convertAwsDateTime(selectedItems[0].endTime) : "-"}
                   />
                 </SpaceBetween>
               </ColumnLayout>


### PR DESCRIPTION
… is in progress

*Issue [#380](https://github.com/aws-samples/iam-identity-center-team/issues/380), if available:*

*Description of changes:*

This PR updates the UI to display a "-" for the session "EndTime" value until a session has ended, just as it does on the *Audit > Elevated Access* page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
