### PR TITLE
fix: missing dependencies in pipfiles causing build failures

### DIFF
--- a/amplify/backend/function/team06dbb7fcPreTokenGeneration/Pipfile
+++ b/amplify/backend/function/team06dbb7fcPreTokenGeneration/Pipfile
@@ -7,6 +7,8 @@ verify_ssl = true
 
 [packages]
 src = {editable = true, path = "./src"}
+setuptools = "*"
+wheel = "*"
 
 [requires]
 python_version = "3.8"

--- a/amplify/backend/function/teamGetPermissionSets/Pipfile
+++ b/amplify/backend/function/teamGetPermissionSets/Pipfile
@@ -11,6 +11,8 @@ requests = "*"
 requests-aws-sign = "*"
 boto3 = "*"
 botocore = "*"
+setuptools = "*"
+wheel = "*"
 
 [requires]
 python_version = "3.9"

--- a/amplify/backend/function/teamListGroups/Pipfile
+++ b/amplify/backend/function/teamListGroups/Pipfile
@@ -7,6 +7,8 @@ verify_ssl = true
 
 [packages]
 src = {editable = true, path = "./src"}
+setuptools = "*"
+wheel = "*"
 
 [requires]
 python_version = "3.9"

--- a/amplify/backend/function/teamNotifications/Pipfile
+++ b/amplify/backend/function/teamNotifications/Pipfile
@@ -9,6 +9,8 @@ verify_ssl = true
 src = {editable = true, path = "./src"}
 boto3 = "*"
 slack_sdk = "*"
+setuptools = "*"
+wheel = "*"
 
 [requires]
 python_version = "3.9"

--- a/amplify/backend/function/teamPublishOUs/Pipfile
+++ b/amplify/backend/function/teamPublishOUs/Pipfile
@@ -9,6 +9,8 @@ verify_ssl = true
 src = {editable = true, path = "./src"}
 requests = "*"
 requests-aws-sign = "*"
+setuptools = "*"
+wheel = "*"
 
 [requires]
 python_version = "3.9"

--- a/amplify/backend/function/teamRouter/Pipfile
+++ b/amplify/backend/function/teamRouter/Pipfile
@@ -11,6 +11,8 @@ requests = "*"
 requests-aws-sign = "*"
 boto3 = "*"
 botocore = "*"
+setuptools = "*"
+wheel = "*"
 
 [requires]
 python_version = "3.9"

--- a/amplify/backend/function/teamgetEntitlement/Pipfile
+++ b/amplify/backend/function/teamgetEntitlement/Pipfile
@@ -11,6 +11,8 @@ requests = "*"
 requests-aws-sign = "*"
 boto3 = "*"
 botocore = "*"
+setuptools = "*"
+wheel = "*"
 
 [requires]
 python_version = "3.9"

--- a/amplify/backend/function/teamgetMgmtAccountDetails/Pipfile
+++ b/amplify/backend/function/teamgetMgmtAccountDetails/Pipfile
@@ -7,6 +7,8 @@ verify_ssl = true
 
 [packages]
 src = {editable = true, path = "./src"}
+setuptools = "*"
+wheel = "*"
 
 [requires]
 python_version = "3.9"

--- a/amplify/backend/function/teamgetUserPolicy/Pipfile
+++ b/amplify/backend/function/teamgetUserPolicy/Pipfile
@@ -7,6 +7,8 @@ verify_ssl = true
 
 [packages]
 src = {editable = true, path = "./src"}
+setuptools = "*"
+wheel = "*"
 
 [requires]
 python_version = "3.9"


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/iam-identity-center-team/issues/393

*Description of changes:*
The builds are failing in amplify due to missing dependencies, these changing allowed the build to deploy successfully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
