### PR TITLE
Retry on SsoAdmin.ThrottlingException

### DIFF
--- a/amplify/backend/custom/stepfunctions/stepfunctions-cloudformation-template.json
+++ b/amplify/backend/custom/stepfunctions/stepfunctions-cloudformation-template.json
@@ -86,7 +86,7 @@
               "ResultPath": "$.grant",
               "Retry": [
                 {
-                  "ErrorEquals": ["ThrottlingException", "ServiceUnavailable", "InternalServerError"],
+                  "ErrorEquals": ["SsoAdmin.ThrottlingException", "ThrottlingException", "ServiceUnavailable", "InternalServerError"],
                   "IntervalSeconds": 3,
                   "BackoffRate": 2,
                   "MaxAttempts": 5
@@ -615,7 +615,7 @@
               "ResultPath": "$.revoke",
               "Retry": [
                 {
-                  "ErrorEquals": ["ThrottlingException", "ServiceUnavailable", "InternalServerError"],
+                  "ErrorEquals": ["SsoAdmin.ThrottlingException", "ThrottlingException", "ServiceUnavailable", "InternalServerError"],
                   "IntervalSeconds": 3,
                   "BackoffRate": 2,
                   "MaxAttempts": 5


### PR DESCRIPTION
*Issue #, if available:*
Retry is configured on role assignment and removal but does not work.

*Description of changes:*
Added the correct Exception to enable proper retry on SsoAdmin.ThrottlingException. I also quickly added the error on our own test-instance and provoked a throttling exception to verify the retry behaviour. We could probably remove the other exceptions, however I did not have the time to look into this more, feel free to adjust.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
