### PR TITLE
Fix duplicate Slack channel notifications

### DIFF
--- a/amplify/backend/function/teamNotifications/src/index.py
+++ b/amplify/backend/function/teamNotifications/src/index.py
@@ -179,61 +179,61 @@ def send_slack_notifications(
                 f"Error posting chat message to channel/user id {recipient_slack_id}: {error}"
             )
 
-        # send audit notifications to channel if defined
-        if slack_audit_notifications_channel and audit_message:
-            try:
-                slack_client.chat_postMessage(
-                    channel=slack_audit_notifications_channel,
-                    text="AWS Access Request Audit Notification",
-                    blocks=[
-                        {
-                            "type": "section",
+    # send audit notifications to channel if defined
+    if slack_audit_notifications_channel and audit_message:
+        try:
+            slack_client.chat_postMessage(
+                channel=slack_audit_notifications_channel,
+                text="AWS Access Request Audit Notification",
+                blocks=[
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": f"*{audit_message}*",
+                        },
+                        "accessory": {
+                            "type": "button",
                             "text": {
+                                "type": "plain_text",
+                                "text": "Open TEAM",
+                            },
+                            "url": login_url,
+                            "action_id": "button-action",
+                        },
+                    },
+                    {
+                        "type": "section",
+                        "fields": [
+                            {
                                 "type": "mrkdwn",
-                                "text": f"*{audit_message}*",
+                                "text": f"*Account:*\n{account}",
                             },
-                            "accessory": {
-                                "type": "button",
-                                "text": {
-                                    "type": "plain_text",
-                                    "text": "Open TEAM",
-                                },
-                                "url": login_url,
-                                "action_id": "button-action",
+                            {
+                                "type": "mrkdwn",
+                                "text": f"*Start time:*\n{formatted_date}",
                             },
-                        },
-                        {
-                            "type": "section",
-                            "fields": [
-                                {
-                                    "type": "mrkdwn",
-                                    "text": f"*Account:*\n{account}",
-                                },
-                                {
-                                    "type": "mrkdwn",
-                                    "text": f"*Start time:*\n{formatted_date}",
-                                },
-                                {"type": "mrkdwn", "text": f"*Role:*\n{role}"},
-                                {
-                                    "type": "mrkdwn",
-                                    "text": f"*Duration:*\n{duration_hours} hours",
-                                },
-                                {
-                                    "type": "mrkdwn",
-                                    "text": f"*Justification:*\n{justification}",
-                                },
-                                {
-                                    "type": "mrkdwn",
-                                    "text": f"*Ticket Number:*\n{ticket}",
-                                },
-                            ],
-                        },
-                    ],
-                )
-            except Exception as error:
-                print(
-                    f"Error posting audit message to channel {slack_audit_notifications_channel} (ensure bot is invited to the channel): {error}"
-                )
+                            {"type": "mrkdwn", "text": f"*Role:*\n{role}"},
+                            {
+                                "type": "mrkdwn",
+                                "text": f"*Duration:*\n{duration_hours} hours",
+                            },
+                            {
+                                "type": "mrkdwn",
+                                "text": f"*Justification:*\n{justification}",
+                            },
+                            {
+                                "type": "mrkdwn",
+                                "text": f"*Ticket Number:*\n{ticket}",
+                            },
+                        ],
+                    },
+                ],
+            )
+        except Exception as error:
+            print(
+                f"Error posting audit message to channel {slack_audit_notifications_channel} (ensure bot is invited to the channel): {error}"
+            )
 
 
 def lambda_handler(event: dict, context):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR fixes an issue where notifications sent to a Slack channel were duplicated, one for each approver and/or requester involved. Since the notifications are intended for the channel as a whole rather than individual recipients, sending multiple identical messages was unnecessary and created noise.

With this fix, a single notification is posted to the Slack channel per event, regardless of the number of approvers or the requester.

*Before (example of duplicates):*
<img width="673" height="880" alt="image" src="https://github.com/user-attachments/assets/42aed4a6-56fa-41cd-9f9e-2b3f38118274" />

*After:*
A single notification is sent to the channel per action.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
