### PR TITLE
Fix Slow loading time of Account list dropdown #362

### DIFF
--- a/amplify/backend/function/teamgetAccounts/teamgetAccounts-cloudformation-template.json
+++ b/amplify/backend/function/teamgetAccounts/teamgetAccounts-cloudformation-template.json
@@ -282,6 +282,38 @@
         "LambdaExecutionRole",
         "AccountsCacheTable"
       ]
+    },
+    "SelfInvokePolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "self-invoke-policy",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "lambda:InvokeFunction"
+              ],
+              "Resource": {
+                "Fn::GetAtt": [
+                  "LambdaFunction",
+                  "Arn"
+                ]
+              }
+            }
+          ]
+        },
+        "Roles": [
+          {
+            "Ref": "LambdaExecutionRole"
+          }
+        ]
+      },
+      "DependsOn": [
+        "LambdaExecutionRole",
+        "LambdaFunction"
+      ]
     }
   },
   "Outputs": {


### PR DESCRIPTION
## Problem
The Target Account dropdown in the request form was experiencing slow loading times when fetching AWS accounts from Organizations API, especially in environments with 400+ accounts. Each API call to `list_accounts` could take up to 2 minutes, causing poor user experience.

Related Issue: #362

## Solution
Implemented a server-side caching mechanism using DynamoDB with a **stale-while-revalidate** pattern.

To ensure reliability in AWS Lambda, this implementation uses **asynchronous self-invocation** for background updates instead of threading. This ensures:
- **Fast response times**: Users get cached data immediately (even if expired).
- **Reliable updates**: The cache refresh runs in a separate, dedicated Lambda invocation, avoiding frozen execution contexts.
- **Graceful fallback**: If the API fails, expired cache is returned.

## Changes

### 1. Lambda Function ([teamgetAccounts/src/index.py](cci:7://file:///Users/matiasfernandez/git-teams/iam-identity-center-team/amplify/backend/function/teamgetAccounts/src/index.py:0:0-0:0))
- **DynamoDB Cache**: Implemented read/write operations.
- **Async Self-Invocation**: When cache is expired, the Lambda invokes itself asynchronously (`InvocationType='Event'`) to refresh the data in the background.
- **Logic**:
    - [get_cached_accounts()](cci:1://file:///Users/matiasfernandez/git-teams/iam-identity-center-team/amplify/backend/function/teamgetAccounts/src/index.py:33:0-63:28): Returns data + expiration status.
    - [handler](cci:1://file:///Users/matiasfernandez/git-teams/iam-identity-center-team/amplify/backend/function/teamgetAccounts/src/index.py:130:0-168:13): Checks for `refresh_cache` event to route to update logic, or handles user request.

### 2. CloudFormation Template ([teamgetAccounts-cloudformation-template.json](cci:7://file:///Users/matiasfernandez/git-teams/iam-identity-center-team/amplify/backend/function/teamgetAccounts/teamgetAccounts-cloudformation-template.json:0:0-0:0))
- **New DynamoDB Table**: `team-accounts-cache` (PAY_PER_REQUEST, TTL enabled).
- **IAM Permissions**:
    - Added DynamoDB read/write permissions.
    - **Added `lambda:InvokeFunction`** permission to allow the function to trigger its own background update.