### PR TITLE
Fix getDuration to properly apply Eligibility Policy duration

### DIFF
--- a/src/components/Requests/Request.js
+++ b/src/components/Requests/Request.js
@@ -93,13 +93,24 @@ function Request(props) {
 
   async function getDuration(accountId) {
     setDuration("");
-    const duration = item.map((data) => {
-      data.accounts.map((account, index) => {
-        if (account.id == accountId) {
-          setMaxDuration(data.duration);
+    let minDuration = null;
+    
+    item.forEach((data) => {
+      const matchingAccount = data.accounts.find(
+        (account) => String(account.id) === String(accountId)
+      );
+      
+      if (matchingAccount) {
+        const policyDuration = parseInt(data.duration, 10);
+        if (minDuration === null || policyDuration < minDuration) {
+          minDuration = policyDuration;
         }
-      });
+      }
     });
+    
+    if (minDuration !== null) {
+      setMaxDuration(minDuration);
+    }
   }
 
   async function getPermissions(accountId) {


### PR DESCRIPTION
## Summary

Fixes #433 - Eligibility Policy max duration not being applied correctly in the request form.

## Problem

When a user selects an account in the request form, the `maxDuration` value from the Eligibility Policy is not applied correctly. The Settings' "Maximum request duration" (e.g., 720 hours) is used instead of the policy's "Max duration" (e.g., 9 hours).

## Root Cause

The `getDuration` function in `Request.js` had the following issues:

1. **Loose comparison (`==`)** - Account ID comparison could fail due to type mismatch
2. **Improper handling of multiple policies** - When multiple policies match, the last value overwrites previous ones instead of using the most restrictive
3. **Misuse of `map()`** - Using `map()` without utilizing its return value made the logic unclear

## Changes

- Use `String()` for type-safe strict comparison (`===`)
- When multiple policies match an account, apply the **minimum duration** (most restrictive)
- Refactor to use `forEach` + `find` for clearer logic

## Testing

1. Set Eligibility Policy with Max duration = 9 hours for an OU
2. Select an account under that OU in the request form
3. Verify that entering duration > 9 shows validation error ✅
4. Verify that the request cannot be submitted with duration > 9 ✅