### PR TITLE
Fix Approval state machine to send correct mail on request expiry

### DIFF
--- a/amplify/backend/custom/stepfunctions/stepfunctions-cloudformation-template.json
+++ b/amplify/backend/custom/stepfunctions/stepfunctions-cloudformation-template.json
@@ -785,7 +785,7 @@
               "Type": "Choice"
             },
             "Update Request Status": {
-              "Next": "Notify Requester Expired",
+              "Next": "Update Status Field",
               "Parameters": {
                 "FunctionName.$": "$.fn_teamstatus_arn",
                 "Payload.$": "$"
@@ -806,6 +806,12 @@
                 }
               ],
               "Type": "Task"
+            },
+            "Update Status Field": {
+              "Type": "Pass",
+              "Next": "Notify Requester Expired",
+              "Result": "expired",
+              "ResultPath": "$.status"
             },
             "Wait": {
               "Next": "DynamoDB GetStatus",


### PR DESCRIPTION
### Summary
Fixes #450 - Incorrect Email Sent When PAM Access Request Expires

### Description of changes:
Updated Approval state machine to correctly change request status from `pending` to `expired` when the approval window passes. Added "Update Status Field" pass state to set status to `expired` in payload before invoking notification Lambda, ensuring correct email template is selected.

### Testing
1. Configure the `Request expiry timeout` setting to the minimum of 1 hour.
1. Raise a new request.
2. Do not approve the request for 1+ hour.
3. Verify the expiry email is received after the expiration period.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
