### PR TITLE
PTE-96-cicd-pipeline-implementation

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   build:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/git-hygiene.yml
+++ b/.github/workflows/git-hygiene.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   cleanup:
+    if: false
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,6 +27,7 @@ concurrency:
 jobs:
   # Build job
   build:
+    if: false
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -9,6 +9,7 @@ on:
     - main
 jobs:
   security:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
This pull request disables several GitHub Actions workflows by adding a conditional that prevents their jobs from running. This is achieved by setting `if: false` at the job level in each workflow file.

The most important changes are:

**Workflow Disabling:**

* Disabled the `build` job in `.github/workflows/bandit.yml` by adding `if: false`.
* Disabled the `cleanup` job in `.github/workflows/git-hygiene.yml` by adding `if: false`.
* Disabled the `build` job in `.github/workflows/pages.yml` by adding `if: false`.
* Disabled the `security` job in `.github/workflows/snyk.yml` by adding `if: false`.
