### PR TITLE
fix: use Amplify dependsOn for SNS topic instead of CloudFormation Export

### DIFF
--- a/amplify/backend/backend-config.json
+++ b/amplify/backend/backend-config.json
@@ -111,6 +111,13 @@
       "dependsOn": [
         {
           "attributes": [
+            "NotificationTopicArn"
+          ],
+          "category": "custom",
+          "resourceName": "sns"
+        },
+        {
+          "attributes": [
             "Arn"
           ],
           "category": "function",
@@ -178,6 +185,13 @@
       "dependsOn": [
         {
           "attributes": [
+            "NotificationTopicArn"
+          ],
+          "category": "custom",
+          "resourceName": "sns"
+        },
+        {
+          "attributes": [
             "GraphQLAPIIdOutput"
           ],
           "category": "api",
@@ -205,6 +219,13 @@
     "teamRouter": {
       "build": true,
       "dependsOn": [
+        {
+          "attributes": [
+            "NotificationTopicArn"
+          ],
+          "category": "custom",
+          "resourceName": "sns"
+        },
         {
           "attributes": [
             "GraphQLAPIIdOutput",

--- a/amplify/backend/custom/sns/sns-cloudformation-template.json
+++ b/amplify/backend/custom/sns/sns-cloudformation-template.json
@@ -30,9 +30,6 @@
       "Description": "The ARN of the SNS topic where TEAM notifications will be sent",
       "Value": {
         "Ref": "snsNotificationTopic"
-      },
-      "Export": {
-        "Name": "NotificationTopicArn"
       }
     }
   }

--- a/amplify/backend/custom/stepfunctions/stepfunctions-cloudformation-template.json
+++ b/amplify/backend/custom/stepfunctions/stepfunctions-cloudformation-template.json
@@ -11,6 +11,10 @@
     "functionteamNotificationsArn": {
       "Type": "String",
       "Description": "Input parameter describing Arn attribute for function/teamNotifications resource"
+    },
+    "customsnsNotificationTopicArn": {
+      "Type": "String",
+      "Description": "Input parameter describing NotificationTopicArn attribute for custom/sns resource"
     }
   },
   "Resources": {
@@ -886,7 +890,7 @@
                   "Effect": "Allow",
                   "Action": "sns:Publish",
                   "Resource": {
-                    "Fn::ImportValue": "NotificationTopicArn"
+                    "Ref": "customsnsNotificationTopicArn"
                   }
                 },
                 {
@@ -974,7 +978,7 @@
                   "Effect": "Allow",
                   "Action": "sns:Publish",
                   "Resource": {
-                    "Fn::ImportValue": "NotificationTopicArn"
+                    "Ref": "customsnsNotificationTopicArn"
                   }
                 },
                 {
@@ -1157,7 +1161,7 @@
                   "Effect": "Allow",
                   "Action": "sns:Publish",
                   "Resource": {
-                    "Fn::ImportValue": "NotificationTopicArn"
+                    "Ref": "customsnsNotificationTopicArn"
                   }
                 },
                 {
@@ -1248,7 +1252,7 @@
                   "Effect": "Allow",
                   "Action": "sns:Publish",
                   "Resource": {
-                    "Fn::ImportValue": "NotificationTopicArn"
+                    "Ref": "customsnsNotificationTopicArn"
                   }
                 },
                 {

--- a/amplify/backend/function/teamNotifications/teamNotifications-cloudformation-template.json
+++ b/amplify/backend/function/teamNotifications/teamNotifications-cloudformation-template.json
@@ -14,6 +14,10 @@
     "apiteamGraphQLAPIIdOutput": {
       "Type": "String",
       "Default": "apiteamGraphQLAPIIdOutput"
+    },
+    "customsnsNotificationTopicArn": {
+      "Type": "String",
+      "Default": "customsnsNotificationTopicArn"
     }
   },
   "Conditions": {
@@ -192,7 +196,7 @@
                 "sns:Publish"
               ],
               "Resource": {
-                "Fn::ImportValue": "NotificationTopicArn"
+                "Ref": "customsnsNotificationTopicArn"
               }
             }
           ]

--- a/amplify/backend/function/teamRouter/teamRouter-cloudformation-template.json
+++ b/amplify/backend/function/teamRouter/teamRouter-cloudformation-template.json
@@ -58,6 +58,10 @@
     "functionteamNotificationsArn": {
       "Type": "String",
       "Default": "functionteamNotificationsArn"
+    },
+    "customsnsNotificationTopicArn": {
+      "Type": "String",
+      "Default": "customsnsNotificationTopicArn"
     }
   },
   "Conditions": {
@@ -127,7 +131,7 @@
               }
             },
             "NOTIFICATION_TOPIC_ARN": {
-              "Fn::ImportValue": "NotificationTopicArn"
+              "Ref": "customsnsNotificationTopicArn"
             },
             "API_TEAM_GRAPHQLAPIENDPOINTOUTPUT": {
               "Ref": "apiteamGraphQLAPIEndpointOutput"


### PR DESCRIPTION
Replace Fn::ImportValue with Ref parameters for NotificationTopicArn to fix stack deletion order. CloudFormation Exports create hard dependencies that block deletion, while Amplify's dependsOn system properly manages nested stack teardown order.

*Description of changes:*

When I deleted the amplify backend stack I ran into these errors:


>Delete canceled. Cannot delete export NotificationTopicArn as it is in use by amplify-teamidcapp-main-6d631-customstepfunctions-AHUY8P61ZC6Q, amplify-teamidcapp-main-6d631-functionteamNotifications-PYJ5CRR3JA4E and amplify-teamidcapp-main-6d631-functionteamRouter-JG2GI7SHFJE2.


>Embedded stack arn:aws:cloudformation:us-east-1:032880537510:stack/amplify-teamidcapp-main-6d631-customsns-GVT4BJ5SHWBF/b0b46300-f315-11f0-bbb4-0ecaddfeaf0f was not successfully deleted: Delete canceled. Cannot delete export NotificationTopicArn as it is in use by amplify-teamidcapp-main-6d631-customstepfunctions-AHUY8P61ZC6Q, amplify-teamidcapp-main-6d631-functionteamNotifications-PYJ5CRR3JA4E and amplify-teamidcapp-main-6d631-functionteamRouter-JG2GI7SHFJE2.

>The following resource(s) failed to delete: [customsns].

This PR addresses this issue by using Amplify dependsOn.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
