### PR TITLE
fix: improve Approve Requests page performance with byStatus GSI

### DIFF
--- a/amplify/backend/api/team/schema.graphql
+++ b/amplify/backend/api/team/schema.graphql
@@ -31,6 +31,10 @@ type requests
   duration: String!
   justification: String
   status: String
+  @index(
+    name: "byStatus"
+    queryField: "requestByStatus"
+  )
   @auth(
     rules: [
       { allow: groups, groups: ["Auditors"], operations: [read] }

--- a/src/components/Approvals/Approvals.js
+++ b/src/components/Approvals/Approvals.js
@@ -24,7 +24,7 @@ import {
   onUpdateRequests,
   onCreateRequests,
 } from "../../graphql/subscriptions";
-import { updateStatus, sessions, getRequest, getSetting } from "../Shared/RequestService";
+import { updateStatus, getRequest, getSetting, getPendingRequests } from "../Shared/RequestService";
 import { useHistory } from "react-router-dom";
 import Status from "../Shared/Status";
 import "../../index.css";
@@ -234,10 +234,7 @@ function Approvals(props) {
   }, []);
 
   function views() {
-    let filter = {
-      and: [{ email: { ne: props.user } }, { status: { eq: "pending" } }, { approvers: { contains: props.user } }],
-    };
-    sessions(filter).then((items) => {
+    getPendingRequests(props.user).then((items) => {
       items.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
       setAllItems(items);
       setTableLoading(false);
@@ -250,10 +247,7 @@ function Approvals(props) {
 
   // Refresh data without resetting UI state (used by subscriptions)
   function refreshItems() {
-    let filter = {
-      and: [{ email: { ne: props.user } }, { status: { eq: "pending" } }, { approvers: { contains: props.user } }],
-    };
-    sessions(filter).then((items) => {
+    getPendingRequests(props.user).then((items) => {
       items.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
       setAllItems(items);
     });

--- a/src/components/Shared/RequestService.js
+++ b/src/components/Shared/RequestService.js
@@ -22,7 +22,8 @@ import {
   listGroups,
   getSettings,
   getMgmtPermissions,
-  getUserPolicy
+  getUserPolicy,
+  requestByStatus
 } from "../../graphql/queries";
 import {
   createRequests,
@@ -210,6 +211,33 @@ export async function sessions(filter) {
   } catch (err) {
     console.log("error fetching sessions");
     return {"error":err}
+  }
+}
+
+export async function getPendingRequests(userEmail) {
+  let nextToken = null;
+  let data = [];
+  try {
+    do {
+      const request = await API.graphql(
+        graphqlOperation(requestByStatus, {
+          status: "pending",
+          filter: {
+            and: [
+              { email: { ne: userEmail } },
+              { approvers: { contains: userEmail } },
+            ],
+          },
+          nextToken,
+        })
+      );
+      data = data.concat(request.data.requestByStatus.items);
+      nextToken = request.data.requestByStatus.nextToken;
+    } while (nextToken);
+    return data;
+  } catch (err) {
+    console.log("error fetching pending requests");
+    return { error: err };
   }
 }
 

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -173,6 +173,54 @@ export const requestByApproverAndStatus = /* GraphQL */ `
     }
   }
 `;
+export const requestByStatus = /* GraphQL */ `
+  query RequestByStatus(
+    $status: String!
+    $sortDirection: ModelSortDirection
+    $filter: ModelrequestsFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    requestByStatus(
+      status: $status
+      sortDirection: $sortDirection
+      filter: $filter
+      limit: $limit
+      nextToken: $nextToken
+    ) {
+      items {
+        id
+        email
+        accountId
+        accountName
+        role
+        roleId
+        startTime
+        duration
+        justification
+        status
+        comment
+        username
+        approver
+        approverId
+        approvers
+        approver_ids
+        revoker
+        revokerId
+        endTime
+        ticketNo
+        revokeComment
+        session_duration
+        createdAt
+        updatedAt
+        owner
+        __typename
+      }
+      nextToken
+      __typename
+    }
+  }
+`;
 export const getSessions = /* GraphQL */ `
   query GetSessions($id: ID!) {
     getSessions(id: $id) {

--- a/src/models/schema.js
+++ b/src/models/schema.js
@@ -210,6 +210,16 @@ export const schema = {
                     }
                 },
                 {
+                    "type": "key",
+                    "properties": {
+                        "name": "byStatus",
+                        "queryField": "requestByStatus",
+                        "fields": [
+                            "status"
+                        ]
+                    }
+                },
+                {
                     "type": "auth",
                     "properties": {
                         "rules": [


### PR DESCRIPTION
### Issue

https://github.com/aws-samples/iam-identity-center-team/issues/501

### Description of changes

Fixed the slow rendering issue on the Approve Requests page.

Currently, `listRequests` performs a full table scan on DynamoDB. Due to DynamoDB's limit on the amount of data that can be retrieved per scan, this results in a large number of API calls.

This PR adds a new GSI (`byStatus`) on the `status` field and uses the `requestByStatus` query to efficiently retrieve only records with `status=pending`. This eliminates the need for full table scans and significantly reduces the number of API calls.

Changes:
- `schema.graphql`: Add `byStatus` GSI on the `status` field
- `queries.js`: Add `requestByStatus` query
- `RequestService.js`: Add `getPendingRequests()` function to fetch only pending requests via GSI
- `Approvals.js`: Replace `sessions(filter)` with `getPendingRequests()`
- `schema.js`: Add `byStatus` key definition

### Testing

1. Inserted a large number of request records (approximately 60,000 in my environment) into the DynamoDB table
2. Opened the Approval Requests page before the fix → approximately 600 GraphQL requests were made (page took about 60 seconds to load)
3. Opened the Approval Requests page after the fix → approximately 50 GraphQL requests were made (page took about 7 seconds to load)
4. Confirmed that the number of displayed items remains the same before and after the fix
