### PR TITLE
fix: process all DynamoDB Stream records in teamRouter handler

### DIFF
--- a/amplify/backend/function/teamRouter/src/index.py
+++ b/amplify/backend/function/teamRouter/src/index.py
@@ -500,8 +500,7 @@ def request_is_updated(status,data,username,request_id):
         updated = True
     return updated
 
-def handler(event, context):
-    data = event["Records"].pop()["dynamodb"]["NewImage"]
+def process_record(data):
     print("Checking if request is updated")
     status = data["status"]["S"]
     username = data["username"]["S"]
@@ -530,4 +529,9 @@ def handler(event, context):
             invoke_workflow(request, approval_required, notification_config, team_config)
     else:
         print("Request not updated")
-        
+
+def handler(event, context):
+    for record in event["Records"]:
+        data = record["dynamodb"]["NewImage"]
+        process_record(data)
+


### PR DESCRIPTION
The `handler` function in `teamRouter` uses `event["Records"].pop()` which only processes the last 1 record in a DynamoDB Streams batch. 
But event source mapping is configured with `BatchSize: 10` so up to 9 records can be silently dropped per invocation. The Lambda returns success, so dropped records are never retried.

The issue causes requests to get permanently stuck in `pending` status under concurrent load eg. during incidents when multiple users request elevated access simultaneously.