### PR TITLE
fix: retry SsoAdmin.ConflictException in Grant and Revoke state machines

### DIFF
--- a/amplify/backend/custom/stepfunctions/stepfunctions-cloudformation-template.json
+++ b/amplify/backend/custom/stepfunctions/stepfunctions-cloudformation-template.json
@@ -86,7 +86,7 @@
               "ResultPath": "$.grant",
               "Retry": [
                 {
-                  "ErrorEquals": ["SsoAdmin.ThrottlingException", "ThrottlingException", "ServiceUnavailable", "InternalServerError"],
+                  "ErrorEquals": ["SsoAdmin.ConflictException", "ConflictException", "SsoAdmin.ThrottlingException", "ThrottlingException", "ServiceUnavailable", "InternalServerError"],
                   "IntervalSeconds": 3,
                   "BackoffRate": 2,
                   "MaxAttempts": 5
@@ -615,7 +615,7 @@
               "ResultPath": "$.revoke",
               "Retry": [
                 {
-                  "ErrorEquals": ["SsoAdmin.ThrottlingException", "ThrottlingException", "ServiceUnavailable", "InternalServerError"],
+                  "ErrorEquals": ["SsoAdmin.ConflictException", "ConflictException", "SsoAdmin.ThrottlingException", "ThrottlingException", "ServiceUnavailable", "InternalServerError"],
                   "IntervalSeconds": 3,
                   "BackoffRate": 2,
                   "MaxAttempts": 5


### PR DESCRIPTION
### Summary:
Issue #513 - Grant and Revoke state machines do not retry on SsoAdmin.ConflictException"

### Description of changes:
The Grant Permission (createAccountAssignment) and Revoke Permission (deleteAccountAssignment) steps only retried on ThrottlingException, ServiceUnavailable, and InternalServerError. SsoAdmin.ConflictException was missing, causing access requests to fail with 'error' status when a new session's grant races with the revocation of a previous session for the same user/role/account combination.

AWS API docs explicitly recommend retrying ConflictException with backoff: https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_CreateAccountAssignment.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
