### PR TITLE
feat: add NOTIFICATION_BUTTON_URL to override notification button target

### DIFF
--- a/amplify/backend/function/teamRouter/parameters.json
+++ b/amplify/backend/function/teamRouter/parameters.json
@@ -1,3 +1,4 @@
 {
-    "SSOLoginUrl": "https://d-9067537589.awsapps.com/start"
+    "SSOLoginUrl": "https://d-9067537589.awsapps.com/start",
+    "NotificationButtonUrl": ""
 }

--- a/amplify/backend/function/teamRouter/src/index.py
+++ b/amplify/backend/function/teamRouter/src/index.py
@@ -28,10 +28,16 @@ schedule = os.getenv("SCHEDULE_SM")
 approval = os.getenv("APPROVAL_SM")
 notification_topic_arn = os.getenv("NOTIFICATION_TOPIC_ARN")
 sso_login_url = os.getenv("SSO_LOGIN_URL")
+# URL used as the "Open TEAM" button target in Slack/SES/SNS notifications.
+# Falls back to SSO_LOGIN_URL so behavior is unchanged when the new variable
+# is not set. Set it (e.g. to the TEAM custom domain) when the SSO portal is
+# also surfaced elsewhere in the UI and you don't want notification buttons
+# to share the same target.
+notification_button_url = os.getenv("NOTIFICATION_BUTTON_URL") or sso_login_url
 fn_teamstatus_arn = os.getenv("FN_TEAMSTATUS_ARN")
 fn_teamnotifications_arn = os.getenv("FN_TEAMNOTIFICATIONS_ARN")
 team_config = {
-    "sso_login_url": sso_login_url,
+    "sso_login_url": notification_button_url,
     "requests_table": requests_table_name,
     "revoke_sm": revoke,
     "grant_sm": grant,

--- a/amplify/backend/function/teamRouter/teamRouter-cloudformation-template.json
+++ b/amplify/backend/function/teamRouter/teamRouter-cloudformation-template.json
@@ -19,6 +19,11 @@
     "SSOLoginUrl": {
       "Type": "String"
     },
+    "NotificationButtonUrl": {
+      "Type": "String",
+      "Default": "",
+      "Description": "Optional override for the URL used as the 'Open TEAM' button in notifications. Falls back to SSOLoginUrl when empty."
+    },
     "customstepfunctionsGrantSMOutput": {
       "Type": "String",
       "Default": "customstepfunctionsGrantSMOutput"
@@ -153,6 +158,9 @@
             },
             "SSO_LOGIN_URL": {
               "Ref": "SSOLoginUrl"
+            },
+            "NOTIFICATION_BUTTON_URL": {
+              "Ref": "NotificationButtonUrl"
             },
             "APPROVER_TABLE_NAME": {
               "Fn::ImportValue": {

--- a/deployment/template.yml
+++ b/deployment/template.yml
@@ -4,6 +4,10 @@ Parameters:
   Login:
     Type: String
     Description: IAM IDC Login URL
+  NotificationButtonUrl:
+    Type: String
+    Default: ""
+    Description: Optional override for the "Open TEAM" button URL in notifications. When empty, the SSO login URL is used (default behaviour).
   CloudTrailAuditLogs:
     Type: "String"
     AllowedPattern: "(read_write|read|write|none|arn.*)"
@@ -153,6 +157,8 @@ Resources:
       EnvironmentVariables: 
         - Name: SSO_LOGIN
           Value: !Ref Login
+        - Name: NOTIFICATION_BUTTON_URL
+          Value: !Ref NotificationButtonUrl
         - Name: TEAM_ACCOUNT
           Value: !Ref teamAccount
         - Name: CLOUDTRAIL_AUDIT_LOGS

--- a/parameters.js
+++ b/parameters.js
@@ -6,7 +6,7 @@
 const fs = require("fs");
 const path = require("path");
 
-const { AWS_APP_ID, AWS_BRANCH, SSO_LOGIN, TEAM_ADMIN_GROUP, TEAM_AUDITOR_GROUP, TAGS, CLOUDTRAIL_AUDIT_LOGS, TEAM_ACCOUNT, AMPLIFY_CUSTOM_DOMAIN } = process.env;
+const { AWS_APP_ID, AWS_BRANCH, SSO_LOGIN, NOTIFICATION_BUTTON_URL, TEAM_ADMIN_GROUP, TEAM_AUDITOR_GROUP, TAGS, CLOUDTRAIL_AUDIT_LOGS, TEAM_ACCOUNT, AMPLIFY_CUSTOM_DOMAIN } = process.env;
 
 async function update_auth_parameters() {
   console.log(`updating amplify config for branch "${AWS_BRANCH}"...`);
@@ -91,6 +91,9 @@ async function update_router_parameters() {
   const routerParametersJson = require(routerParametersJsonPath);
 
   routerParametersJson.SSOLoginUrl = SSO_LOGIN;
+  // Optional override for the "Open TEAM" button URL in notifications.
+  // Empty string means "fall back to SSOLoginUrl" (default behaviour).
+  routerParametersJson.NotificationButtonUrl = NOTIFICATION_BUTTON_URL || "";
 
   fs.writeFileSync(
     routerParametersJsonPath,


### PR DESCRIPTION
## Summary

Adds an optional `NOTIFICATION_BUTTON_URL` env var on the `teamRouter` lambda that, when set, overrides the URL placed into the notification payload's `sso_login_url` field (used as the "Open TEAM" button target in Slack/SES/SNS notifications). When unset, behaviour is identical to today (falls back to `SSO_LOGIN_URL`), so this is fully backward compatible.

## Why

Today the same `SSO_LOGIN` build env var is consumed by two separate things:
- **React frontend** (`src/parameters.json` → `params.Login`): renders the "IAM Identity Center" header link, which is supposed to take users to the SSO portal.
- **`teamRouter` lambda** (`SSO_LOGIN_URL` env): becomes the "Open TEAM" button URL on every notification.

For deployments that surface the SSO portal elsewhere in the UI and want the notification button to deep-link straight to the TEAM custom domain instead, there's currently no way to separate the two — changing `SSO_LOGIN` would (mis)point the header link as well. Operators are forced to either live with notifications going via the SSO portal or accept a misleading header link.

## Change

- `deployment/template.yml`: new optional `NotificationButtonUrl` CFN parameter (default `""`); surfaced as `NOTIFICATION_BUTTON_URL` on the Amplify branch's environment variables.
- `parameters.js`: build-time `NOTIFICATION_BUTTON_URL` env var is written into `teamRouter/parameters.json` as `NotificationButtonUrl`. Empty string = fall back.
- `amplify/backend/function/teamRouter/parameters.json`: new `NotificationButtonUrl: ""` field.
- `amplify/backend/function/teamRouter/teamRouter-cloudformation-template.json`: new optional `NotificationButtonUrl` CFN parameter, set as the `NOTIFICATION_BUTTON_URL` env var on the lambda.
- `amplify/backend/function/teamRouter/src/index.py`: read `NOTIFICATION_BUTTON_URL` with fallback to `SSO_LOGIN_URL`; use the result for `sso_login_url` in `team_config`.

The notification payload field name (`sso_login_url`) is unchanged, so `teamNotifications` needs no changes.

## Test plan

Verified end-to-end on a downstream deployment (cherry-picked into a private fork):

- [x] Deploy with `NOTIFICATION_BUTTON_URL=https://team.example.com` → Slack notification "Open TEAM" button deep-links to `https://team.example.com` instead of the SSO portal. Confirmed via real access request, audit-channel button click landed at the custom domain.
- [x] React header "IAM Identity Center" link still points at the SSO portal (uses `params.Login` from the JS bundle, unchanged).
- [x] CloudFormation update applied cleanly on an existing stack — the new optional parameter (default `""`) didn't require any input change.
