### PR TITLE
fix: skip revoke when an overlapping in-progress request still covers the role

### DIFF
--- a/amplify/backend/custom/stepfunctions/stepfunctions-cloudformation-template.json
+++ b/amplify/backend/custom/stepfunctions/stepfunctions-cloudformation-template.json
@@ -596,6 +596,55 @@
               "Default": "DynamoDB Update EndTime",
               "Type": "Choice"
             },
+            "Check Overlapping Sessions": {
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Next": "Revoke Permission",
+                  "ResultPath": "$.overlapError"
+                }
+              ],
+              "Next": "Overlap?",
+              "Parameters": {
+                "TableName.$": "$.requests_table",
+                "FilterExpression": "username = :u AND accountId = :a AND roleId = :r AND #s = :inprogress AND id <> :id",
+                "ExpressionAttributeNames": {
+                  "#s": "status"
+                },
+                "ExpressionAttributeValues": {
+                  ":u": { "S.$": "$.username" },
+                  ":a": { "S.$": "$.accountId" },
+                  ":r": { "S.$": "$.roleId" },
+                  ":inprogress": { "S": "in progress" },
+                  ":id": { "S.$": "$.id" }
+                },
+                "Select": "COUNT"
+              },
+              "Resource": "arn:aws:states:::aws-sdk:dynamodb:scan",
+              "ResultPath": "$.overlapScan",
+              "Retry": [
+                {
+                  "ErrorEquals": ["DynamoDb.ProvisionedThroughputExceededException", "DynamoDb.ThrottlingException", "ThrottlingException", "ServiceUnavailable", "InternalServerError"],
+                  "IntervalSeconds": 2,
+                  "BackoffRate": 2,
+                  "MaxAttempts": 5
+                }
+              ],
+              "Type": "Task"
+            },
+            "Overlap?": {
+              "Choices": [
+                {
+                  "NumericGreaterThan": 0,
+                  "Variable": "$.overlapScan.Count",
+                  "Next": "Notify Requester Session Ended"
+                }
+              ],
+              "Default": "Revoke Permission",
+              "Type": "Choice"
+            },
             "Revoke Permission": {
               "Catch": [
                 {
@@ -654,7 +703,7 @@
                   "Next": "Pass"
                 }
               ],
-              "Default": "Revoke Permission",
+              "Default": "Check Overlapping Sessions",
               "Type": "Choice"
             },
             "Update Request Status": {
@@ -1178,7 +1227,7 @@
                 },
                 {
                   "Effect": "Allow",
-                  "Action": ["dynamodb:UpdateItem", "dynamodb:GetItem"],
+                  "Action": ["dynamodb:UpdateItem", "dynamodb:GetItem", "dynamodb:Scan"],
                   "Resource": {
                     "Fn::Sub": "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/requests*"
                   }


### PR DESCRIPTION
*Issue #, if available:* Closes #279, related #104

*Description of changes:*

The Revoke state machine called `sso:DeleteAccountAssignment` unconditionally on TTL expiry. When a user has two overlapping in-progress requests for the same `username + accountId + roleId`, the earlier expiry tears down the IAM grant the later session still needs.

**Change** — in `RevokeStateMachine` (`amplify/backend/custom/stepfunctions/stepfunctions-cloudformation-template.json`):

- Insert `Check Overlapping Sessions` (DynamoDB `Scan`, `Select=COUNT`) before `Revoke Permission`. Filter matches another item with same `username`, `accountId`, `roleId`, `status = "in progress"`, and a different `id`.
- Add `Overlap?` choice: if `Count > 0`, skip the IAM revoke and route to the existing `Notify Requester Session Ended` -> `Update Request Status` -> `DynamoDB Update EndTime` chain. Expiring request still moves to `ended`; IAM grant left intact for the still-active session to own teardown.
- Catch on the scan falls through to the original `Revoke Permission` path, so a DynamoDB failure never blocks revocation (fail-open preserves the TTL guarantee).
- Add `dynamodb:Scan` to `TEAMRevokeSMRole` on the existing `table/requests*` resource.

**No-overlap path is byte-identical to today.** User-initiated revoke still short-circuits via the existing `Revoked?` early-exit.

**Trade-off:** uses `Scan` because the table has no GSI on `(username, accountId, roleId)`. Fine at typical TEAM scale; a follow-up could add a GSI and switch to `Query`.

**Manual test:**
1. Approve request A (e.g. 1h).
2. ~10 min before A expires, approve request B for the same role/account.
3. When A's TTL fires: `RevokeStateMachine` execution shows `Overlap?` taking the skip branch; `DeleteAccountAssignment` is not called; IAM grant remains.
4. A's row -> `status=ended` with fresh `endTime`.
5. B's TTL later fires the normal path and tears down the grant.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.