### PR TITLE
fix(teamgetIdCGroups): serialize datetime fields in IdC list_groups response

### DIFF
--- a/amplify/backend/function/teamgetIdCGroups/src/index.py
+++ b/amplify/backend/function/teamgetIdCGroups/src/index.py
@@ -4,7 +4,9 @@
 # Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
 from botocore.exceptions import ClientError
 import boto3
+from datetime import date, datetime
 from operator import itemgetter
+
 
 def get_identiy_store_id():
     client = boto3.client('sso-admin')
@@ -18,6 +20,16 @@ def get_identiy_store_id():
 sso_instance = get_identiy_store_id()
 
 
+def jsonify(obj):
+    if isinstance(obj, (datetime, date)):
+        return obj.isoformat()
+    if isinstance(obj, list):
+        return [jsonify(item) for item in obj]
+    if isinstance(obj, dict):
+        return {key: jsonify(value) for key, value in obj.items()}
+    return obj
+
+
 def list_idc_groups(IdentityStoreId):
     try:
         client = boto3.client('identitystore')
@@ -26,7 +38,7 @@ def list_idc_groups(IdentityStoreId):
         all_groups = []
         for page in paginator:
             all_groups.extend(page["Groups"])
-        return sorted(all_groups, key=itemgetter('DisplayName'))
+        return jsonify(sorted(all_groups, key=itemgetter('DisplayName')))
     except ClientError as e:
         print(e.response['Error']['Message'])
 

--- a/amplify/backend/function/teamgetUsers/src/index.py
+++ b/amplify/backend/function/teamgetUsers/src/index.py
@@ -4,7 +4,9 @@
 # Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
 from botocore.exceptions import ClientError
 import boto3
+from datetime import date, datetime
 from operator import itemgetter
+
 
 def get_identiy_store_id():
     client = boto3.client('sso-admin')
@@ -16,7 +18,18 @@ def get_identiy_store_id():
 
 
 sso_instance = get_identiy_store_id()
-        
+
+
+def jsonify(obj):
+    if isinstance(obj, (datetime, date)):
+        return obj.isoformat()
+    if isinstance(obj, list):
+        return [jsonify(item) for item in obj]
+    if isinstance(obj, dict):
+        return {key: jsonify(value) for key, value in obj.items()}
+    return obj
+
+
 def list_idc_users(IdentityStoreId):
     try:
         client = boto3.client('identitystore')
@@ -25,7 +38,7 @@ def list_idc_users(IdentityStoreId):
         all_users = []
         for page in paginator:
             all_users.extend(page["Users"])
-        return sorted(all_users, key=itemgetter('UserName'))
+        return jsonify(sorted(all_users, key=itemgetter('UserName')))
     except ClientError as e:
         print(e.response['Error']['Message'])
 


### PR DESCRIPTION
The administrator approvers page goes blank in deployments where IdC groups carry datetime fields in their API responses. The Lambda returns the raw `list_groups` response, which newer boto3 SDK versions populate with `datetime` objects (e.g. group metadata timestamps). Lambda's Python runtime cannot marshal `datetime` to JSON and rejects the entire response with:

 ```
 [ERROR] Runtime.MarshalError: Unable to marshal response:
  Object of type datetime is not JSON serializable
```

The frontend then receives `null` from the resolver and crashes on `.map()` of undefined, manifesting as a blank admin page.

This Adds a small recursive `jsonify` helper that converts `datetime`/`date` values to ISO 8601 strings while leaving all other fields untouched. Preserves the existing response shape consumed by the frontend.

this PR now also applies the same jsonify fix to `teamgetUsers`. The bug manifests on boto3 >= 1.40.0 per testing from the reviewer. `teamListGroups` (which uses list_group_memberships) was left out, its documented response shape doesn't include `datetime` fields. 

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
