### PR TITLE
feat: deep-link approver notifications straight to the approve modal

### DIFF
--- a/amplify/backend/function/teamNotifications/src/index.py
+++ b/amplify/backend/function/teamNotifications/src/index.py
@@ -291,12 +291,17 @@ def lambda_handler(event: dict, context):
     justification = event.get("justification", "No justification provided")
     ticket = event.get("ticketNo", "No ticket provided")
     login_url = event["sso_login_url"]
+    team_app_url = event.get("team_app_url", "")
+    request_id = event.get("id", "")
+    button_url = login_url
     sns_message = json.dumps(event)
     slack_audit_message = ""
 
     match request_status:
         case "pending":
             if approval_required:
+                if team_app_url and request_id:
+                    button_url = f"{team_app_url.rstrip('/')}/approvals/approve/{request_id}"
                 # Notify approvers pending request
                 slack_recipients = approvers
                 slack_message = f"<mailto:{requester}|{requester}> requests access to AWS, please approve or reject this request in TEAM."
@@ -306,7 +311,7 @@ def lambda_handler(event: dict, context):
                 email_to_addresses = approvers
                 email_cc_addresses = [requester]
                 subject = f"Access request to AWS account - {account}"
-                email_message_html = f'<html><body><p><b>{requester}</b> requests access to AWS, please <b>approve or reject this request</b> in <a href="{login_url}">TEAM</a>.</p><p><b>Account:</b> {account}<br /><b>Role:</b> {role}<br /><b>Start Time:</b> {request_start_time}<br /><b>Duration:</b> {duration_hours} hours<br /><b>Justification:</b> {justification}<br /><b>Ticket Number:</b> {ticket}<br /></p></body></html>'
+                email_message_html = f'<html><body><p><b>{requester}</b> requests access to AWS, please <b>approve or reject this request</b> in <a href="{button_url}">TEAM</a>.</p><p><b>Account:</b> {account}<br /><b>Role:</b> {role}<br /><b>Start Time:</b> {request_start_time}<br /><b>Duration:</b> {duration_hours} hours<br /><b>Justification:</b> {justification}<br /><b>Ticket Number:</b> {ticket}<br /></p></body></html>'
         case "scheduled":
             # Don't need to send a notification if the request start time has already passed
             if datetime.now(timezone.utc) > parser.parse(request_start_time).astimezone(
@@ -407,7 +412,7 @@ def lambda_handler(event: dict, context):
             recipients=slack_recipients,
             message=slack_message,
             audit_message=slack_audit_message,
-            login_url=login_url,
+            login_url=button_url,
             role=role,
             account=account,
             request_start_time=request_start_time,

--- a/amplify/backend/function/teamRouter/src/index.py
+++ b/amplify/backend/function/teamRouter/src/index.py
@@ -28,10 +28,12 @@ schedule = os.getenv("SCHEDULE_SM")
 approval = os.getenv("APPROVAL_SM")
 notification_topic_arn = os.getenv("NOTIFICATION_TOPIC_ARN")
 sso_login_url = os.getenv("SSO_LOGIN_URL")
+team_app_url = os.getenv("TEAM_APP_URL", "")
 fn_teamstatus_arn = os.getenv("FN_TEAMSTATUS_ARN")
 fn_teamnotifications_arn = os.getenv("FN_TEAMNOTIFICATIONS_ARN")
 team_config = {
     "sso_login_url": sso_login_url,
+    "team_app_url": team_app_url,
     "requests_table": requests_table_name,
     "revoke_sm": revoke,
     "grant_sm": grant,

--- a/amplify/backend/function/teamRouter/teamRouter-cloudformation-template.json
+++ b/amplify/backend/function/teamRouter/teamRouter-cloudformation-template.json
@@ -19,6 +19,11 @@
     "SSOLoginUrl": {
       "Type": "String"
     },
+    "TeamAppUrl": {
+      "Type": "String",
+      "Default": "",
+      "Description": "Optional. Public URL of the TEAM web app (e.g. https://main.xxxxx.amplifyapp.com). When set, pending-approval notifications deep-link directly to /approvals/approve/<id> instead of the IAM Identity Center start URL."
+    },
     "customstepfunctionsGrantSMOutput": {
       "Type": "String",
       "Default": "customstepfunctionsGrantSMOutput"
@@ -153,6 +158,9 @@
             },
             "SSO_LOGIN_URL": {
               "Ref": "SSOLoginUrl"
+            },
+            "TEAM_APP_URL": {
+              "Ref": "TeamAppUrl"
             },
             "APPROVER_TABLE_NAME": {
               "Fn::ImportValue": {

--- a/parameters.js
+++ b/parameters.js
@@ -91,6 +91,9 @@ async function update_router_parameters() {
   const routerParametersJson = require(routerParametersJsonPath);
 
   routerParametersJson.SSOLoginUrl = SSO_LOGIN;
+  routerParametersJson.TeamAppUrl = AMPLIFY_CUSTOM_DOMAIN
+    ? `https://${AMPLIFY_CUSTOM_DOMAIN}`
+    : `https://${AWS_BRANCH}.${AWS_APP_ID}.amplifyapp.com`;
 
   fs.writeFileSync(
     routerParametersJsonPath,

--- a/src/components/Approvals/Approvals.js
+++ b/src/components/Approvals/Approvals.js
@@ -2,7 +2,7 @@
 // This AWS Content is provided subject to the terms of the AWS Customer Agreement available at
 // http://aws.amazon.com/agreement or other written agreement between Customer and either
 // Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import {
   Box,
   Button,
@@ -25,7 +25,7 @@ import {
   onCreateRequests,
 } from "../../graphql/subscriptions";
 import { updateStatus, sessions, getRequest, getSetting } from "../Shared/RequestService";
-import { useHistory } from "react-router-dom";
+import { useHistory, useParams } from "react-router-dom";
 import Status from "../Shared/Status";
 import "../../index.css";
 
@@ -207,13 +207,12 @@ function Approvals(props) {
     },
     pagination: { pageSize: preferences.pageSize },
     sorting: {},
-    selection: {
-      trackBy: "id",
-    },
   });
 
-  const { selectedItems } = collectionProps;
+  const [selectedItems, setSelectedItems] = useState([]);
   const history = useHistory();
+  const { id: deepLinkId } = useParams();
+  const autoOpenedRef = useRef(false);
   const [confirmLoading, setConfirmLoading] = useState(false);
   const [refreshLoading, setRefreshLoading] = useState(false);
   const [tableLoading, setTableLoading] = useState(true);
@@ -233,6 +232,31 @@ function Approvals(props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    if (autoOpenedRef.current) return;
+    if (!deepLinkId) return;
+    if (tableLoading) return;
+    autoOpenedRef.current = true;
+    const item = allItems.find((i) => i.id === deepLinkId);
+    if (item) {
+      setSelectedItems([item]);
+      setAction("approved");
+      setmodalHeader("Approve");
+      setVisible(true);
+    } else {
+      props.addNotification([
+        {
+          type: "info",
+          content:
+            "This approval request is not in your pending list. It may have been actioned, expired, or isn't assigned to you.",
+          dismissible: true,
+          onDismiss: () => props.addNotification([]),
+        },
+      ]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [allItems, tableLoading, deepLinkId]);
+
   function views() {
     let filter = {
       and: [{ email: { ne: props.user } }, { status: { eq: "pending" } }, { approvers: { contains: props.user } }],
@@ -245,6 +269,7 @@ function Approvals(props) {
       setVisible(false);
       setRefreshLoading(false);
       setComment();
+      setSelectedItems([]);
     });
   }
 
@@ -420,6 +445,10 @@ function Approvals(props) {
         items={items}
         selectionType="single"
         trackBy="id"
+        selectedItems={selectedItems}
+        onSelectionChange={({ detail }) =>
+          setSelectedItems(detail.selectedItems)
+        }
       />
       <div>
         {selectedItems.length ? (

--- a/src/components/Navigation/Nav.js
+++ b/src/components/Navigation/Nav.js
@@ -94,7 +94,7 @@ function Nav(props) {
                     groupIds={props.groupIds}
                   />
                 </Route>
-                <Route path="/approvals/approve">
+                <Route path="/approvals/approve/:id?">
                   <Approvals
                     addNotification={setNotifications}
                     setActiveHref={setActiveHref}


### PR DESCRIPTION
*Issue #, if available:* #516

*Description of changes:*

Today the Slack/email button on a pending-approval notification opens the IAM Identity Center start URL. The approver then clicks the TEAM tile, navigates to **Approvals**, and finds their row. This PR makes the button deep-link directly to the approve modal for that specific request.

**Approval still goes through the authenticated GraphQL mutation as the SSO-logged-in user** — no public approval endpoint is added, audit log and `approverId` are unaffected.

### Changes

- **`src/components/Navigation/Nav.js`** — extends the existing `/approvals/approve` route to accept an optional `:id` param. The list view still works at `/approvals/approve`.
- **`src/components/Approvals/Approvals.js`** — switches `selectedItems` off the (v1) `useCollection` hook and manages it locally so it can be set programmatically. On mount, if a `:id` is in the URL and the pending list contains a matching row, it selects the row, sets action to `approved`, and opens the modal. A ref guards against re-opening after dismissal. If the id isn't in the user's pending list (already actioned, expired, or not theirs), an info flashbar explains and the page stays on the list.
- **`amplify/backend/function/teamRouter/{src/index.py, teamRouter-cloudformation-template.json}`** — introduces an optional `TeamAppUrl` CFN parameter that flows to the Lambda as `TEAM_APP_URL` and is merged into the step function input as `team_app_url`. Defaults to empty, so existing deployments are unaffected.
- **`amplify/backend/function/teamNotifications/src/index.py`** — when status is `pending` and `team_app_url` is set, the Slack message-block button URL and the email "TEAM" anchor are rewritten to `{team_app_url}/approvals/approve/{request_id}`. All other status branches keep today's behavior.
- **`parameters.js`** — at Amplify build time, auto-populates `TeamAppUrl` using the same domain logic already used for the Cognito OAuth callback (`AMPLIFY_CUSTOM_DOMAIN` if set, otherwise the `amplifyapp.com` URL). No operator configuration required — upgrades pick this up on next Amplify build.

### Known limitation

If the approver's TEAM session is expired when they click the button, Cognito Hosted UI redirects them to the app root after SAML auth rather than back to the deep link (the OAuth callback URL is the app root). They then navigate to Approvals manually — same as today. Approvers with an active session land directly on the modal. Preserving the deep link across the OAuth round-trip would require Amplify Auth state handling and is out of scope for this PR.

### Manual test

1. Submit a request as user A; approver list includes user B.
2. With Slack notifications enabled, user B receives the notification with the existing "Open TEAM" button.
3. User B (already authenticated to TEAM) clicks the button → lands on `/approvals/approve/<id>` → modal for the specific request is open → enter comment → click **Confirm** → request is approved.
4. Repeat with email notification — same deep-link behavior in the email body.
5. Open `/approvals/approve` directly (no id) → list view renders as before.
6. Open `/approvals/approve/<unknown-id>` → list view + info message about request not found.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.