### PR TITLE
fix(PreTokenGeneration): authorize federated users explicitly and fail closed (#546)

### DIFF
--- a/amplify/backend/function/team06dbb7fcPreTokenGeneration/src/index.py
+++ b/amplify/backend/function/team06dbb7fcPreTokenGeneration/src/index.py
@@ -95,10 +95,44 @@ def list_idc_group_membership(userId):
         print(e.response['Error']['Message'])
 
 
+class UnauthorizedError(Exception):
+    """Raised when token generation is attempted for a non-federated user."""
+
+
+def get_federated_identifier(event):
+    """Return the Identity Center identifier for a federated user.
+
+    TEAM authorization (Admin/Auditor claims) is derived from AWS IAM Identity
+    Center group membership and is only meaningful for users that authenticate
+    through the external (SAML) identity provider. Native Cognito users, such as
+    self-registered accounts, must never receive these claims.
+
+    Federation is verified by requiring the Cognito ``identities`` attribute,
+    which is populated only for users linked to an external identity provider.
+    We fail closed if it is absent rather than inferring trust from the shape of
+    the Cognito username.
+    """
+    user_attributes = event.get("request", {}).get("userAttributes", {})
+    if not user_attributes.get("identities"):
+        raise UnauthorizedError(
+            "Token generation denied: user is not federated through the "
+            "external identity provider."
+        )
+
+    user_name = event.get("userName", "")
+    federated_identifier = user_name.split("_", 1)[1] if "_" in user_name else ""
+    if not federated_identifier:
+        raise UnauthorizedError(
+            "Token generation denied: unexpected username format for a "
+            "federated user: '{}'.".format(user_name)
+        )
+    return federated_identifier
+
+
 def handler(event, context):
     team_admin_group, team_auditor_group = get_team_groups()
-    
-    user = event["userName"].split("_", 1)[1]
+
+    user = get_federated_identifier(event)
     userId = get_user(user)
     admin = get_group(team_admin_group)
     auditor = get_group(team_auditor_group)

--- a/tests/test_pretokengeneration.py
+++ b/tests/test_pretokengeneration.py
@@ -1,0 +1,126 @@
+"""Unit tests for the PreTokenGeneration Cognito trigger.
+
+These tests verify that the trigger fails closed for non-federated users
+(for example self-registered Cognito accounts) and only assigns TEAM
+authorization claims for users federated through the external identity
+provider. They stub boto3 so the module can be imported without any AWS calls.
+"""
+import importlib.util
+import os
+import unittest
+from unittest import mock
+
+INDEX_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "amplify",
+    "backend",
+    "function",
+    "team06dbb7fcPreTokenGeneration",
+    "src",
+    "index.py",
+)
+
+
+def load_index():
+    os.environ.setdefault("TEAM_ADMIN_GROUP", "team-admin")
+    os.environ.setdefault("TEAM_AUDITOR_GROUP", "team-auditor")
+    os.environ.setdefault("SETTINGS_TABLE_NAME", "settings-table")
+    # Stub boto3 so importing the module performs no AWS calls.
+    with mock.patch("boto3.client"), mock.patch("boto3.resource"):
+        spec = importlib.util.spec_from_file_location("index", INDEX_PATH)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    return module
+
+
+index = load_index()
+
+
+def federated_event():
+    return {
+        "userName": "IDC_alice@example.com",
+        "request": {
+            "userAttributes": {
+                "email": "alice@example.com",
+                "identities": '[{"providerName":"IDC","userId":"alice@example.com"}]',
+            }
+        },
+    }
+
+
+def native_event(user_name="d2e5d444-a061-70cb-ab77-9cd73bec7d55"):
+    return {
+        "userName": user_name,
+        "request": {"userAttributes": {"email": "attacker@example.com"}},
+    }
+
+
+class FederatedIdentifierTests(unittest.TestCase):
+    def test_native_user_without_identities_is_denied(self):
+        with self.assertRaises(index.UnauthorizedError):
+            index.get_federated_identifier(native_event())
+
+    def test_native_user_with_underscore_but_no_identities_is_denied(self):
+        # Even if the username happens to contain an underscore, a user that is
+        # not federated must be rejected: authorization must not rely on the
+        # username string shape.
+        event = native_event(user_name="idc_attacker@example.com")
+        with self.assertRaises(index.UnauthorizedError):
+            index.get_federated_identifier(event)
+
+    def test_federated_user_returns_identifier(self):
+        self.assertEqual(
+            index.get_federated_identifier(federated_event()),
+            "alice@example.com",
+        )
+
+
+class HandlerTests(unittest.TestCase):
+    def test_handler_denies_non_federated_user(self):
+        with self.assertRaises(index.UnauthorizedError):
+            index.handler(native_event(), None)
+
+    def test_handler_assigns_admin_claim_for_federated_admin(self):
+        groups_by_name = {"team-admin": "g-admin", "team-auditor": "g-aud"}
+        with mock.patch.object(
+            index, "get_team_groups", return_value=("team-admin", "team-auditor")
+        ), mock.patch.object(
+            index, "get_user", return_value="user-123"
+        ), mock.patch.object(
+            index, "get_group", side_effect=lambda g: groups_by_name[g]
+        ), mock.patch.object(
+            index,
+            "list_idc_group_membership",
+            return_value=[{"GroupId": "g-admin"}],
+        ):
+            result = index.handler(federated_event(), None)
+
+        claims = result["response"]["claimsOverrideDetails"]
+        self.assertEqual(claims["claimsToAddOrOverride"]["groups"], "Admin")
+        self.assertEqual(claims["claimsToAddOrOverride"]["userId"], "user-123")
+        self.assertIn(
+            "Admin", claims["groupOverrideDetails"]["groupsToOverride"]
+        )
+
+    def test_handler_assigns_no_privileged_claim_for_federated_non_member(self):
+        with mock.patch.object(
+            index, "get_team_groups", return_value=("team-admin", "team-auditor")
+        ), mock.patch.object(
+            index, "get_user", return_value="user-456"
+        ), mock.patch.object(
+            index, "get_group", side_effect=lambda g: {"team-admin": "g-admin", "team-auditor": "g-aud"}[g]
+        ), mock.patch.object(
+            index,
+            "list_idc_group_membership",
+            return_value=[{"GroupId": "g-other"}],
+        ):
+            result = index.handler(federated_event(), None)
+
+        claims = result["response"]["claimsOverrideDetails"]
+        self.assertEqual(claims["claimsToAddOrOverride"]["groups"], "")
+        self.assertEqual(claims["groupOverrideDetails"]["groupsToOverride"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #546.

The `PreTokenGeneration` trigger derived the user identifier with `event["userName"].split("_", 1)[1]` and relied on the resulting `IndexError` to exclude users who did not arrive through the SAML identity provider. As a result, authorization (the `Admin` / `Auditor` group claims) was inferred from the **shape of the Cognito username**, and native Cognito users (e.g. self-registered accounts) were excluded only incidentally — any change that handled the missing username segment, or any pool whose usernames can contain `_`, would let a non-federated user through into the Identity Center group lookup.

## Changes

- Add `get_federated_identifier(event)` which **verifies the user is federated** by requiring the Cognito `identities` attribute (populated only for users linked to an external IdP) and **fails closed** with an explicit `UnauthorizedError` otherwise — instead of trusting the username shape.
- The username is still used to recover the federated identifier, but only after federation has been confirmed, and the parse is guarded.
- Add unit tests (stdlib `unittest`, boto3 stubbed so no AWS calls) covering:
  - non-federated user denied (with and without an underscore in the username),
  - federated admin receives the `Admin` claim,
  - federated non-member receives no privileged claim.

## Behavior

No change for legitimate flows: federated users get the same claims as before, and non-federated users still receive no token — but now by an **explicit, logged authorization decision** rather than an uncaught exception.

## Testing

```
$ python3 -m unittest discover -s tests -p "test_*.py"
Ran 6 tests ... OK

$ bandit -r -lll -ii amplify/backend/function/team06dbb7fcPreTokenGeneration/src tests
No issues identified.
```

## Note

Issue #546 also recommends shipping a secure-by-default user pool (`AdminCreateUserConfig.AllowAdminCreateUserOnly = true` to disable public self-registration). That is a separate configuration change and is intentionally left out of this code-only PR; happy to follow up if maintainers would like it bundled.
