### PR TITLE
feat(auth): disable public self-registration on the user pool (#546)

### DIFF
--- a/amplify/backend/auth/team06dbb7fc/override.ts
+++ b/amplify/backend/auth/team06dbb7fc/override.ts
@@ -1,0 +1,18 @@
+import { AmplifyAuthCognitoStackTemplate } from '@aws-amplify/cli-extensibility-helper';
+
+export function override(resources: AmplifyAuthCognitoStackTemplate) {
+  // TEAM is a federated-only application: users authenticate through AWS IAM
+  // Identity Center (SAML). Public self-service sign-up is not used and should
+  // not be possible, otherwise anyone on the internet can create and confirm an
+  // account in the user pool that backs this privileged-access workflow.
+  //
+  // Cognito defaults AdminCreateUserConfig.AllowAdminCreateUserOnly to false,
+  // which permits public SignUp. Force it to true so only admin-created /
+  // federated identities can exist in the pool. Federated (hosted UI / SAML)
+  // sign-in is unaffected, since those users are provisioned via the identity
+  // provider linkage rather than the public SignUp API.
+  resources.userPool.addPropertyOverride(
+    'AdminCreateUserConfig.AllowAdminCreateUserOnly',
+    true
+  );
+}


### PR DESCRIPTION
## Summary

Addresses the secure-default recommendation in #546.

The Cognito user pool that backs TEAM permits **public self-service sign-up**: Amplify
provisions it with the default `AdminCreateUserConfig.AllowAdminCreateUserOnly = false`,
and nothing in the auth config overrides it. As a result anyone on the internet can call
`SignUp`, confirm via email, and create an account in the pool that fronts this
privileged-access workflow.

TEAM is a **federated-only** application — users authenticate through AWS IAM Identity
Center (SAML) — so public self-registration should not be possible at all.

## Change

Add an Amplify auth override (`amplify/backend/auth/team06dbb7fc/override.ts`) that forces:

```
AdminCreateUserConfig.AllowAdminCreateUserOnly = true
```

After this, `SignUp` returns `NotAuthorizedException` ("Sign-up is not permitted for this
user pool"). Federated hosted-UI / SAML sign-in is unaffected, since those users are
provisioned through the identity-provider linkage rather than the public `SignUp` API.

The override uses `addPropertyOverride` and mirrors the existing
`amplify/backend/api/team/override.ts` convention already in the repo.

## Relationship to #546 / the PreTokenGeneration PR

This is the **configuration** half of #546 and is complementary to the code fix for the
`PreTokenGeneration` trigger (separate PR):

- *PreTokenGeneration fix* — stops a non-federated user from receiving a privileged token.
- *This PR* — stops a non-federated user from being **created** in the pool at all (defense in depth).

It is intentionally config-only so it can be reviewed/merged independently.

## Testing / validation

- Structure mirrors the existing working `api/team/override.ts` (same helper import,
  same `addPropertyOverride` mechanism).
- Full `amplify push` validation requires an Amplify environment with AWS credentials,
  which isn't available in this PR's context; reviewers with an env can confirm with:
  ```
  aws cognito-idp describe-user-pool --user-pool-id <pool-id> \
    --query 'UserPool.AdminCreateUserConfig.AllowAdminCreateUserOnly'   # -> true
  aws cognito-idp sign-up --client-id <app-client-id> \
    --username test@example.com --password 'Test123!aaa'                # -> NotAuthorizedException
  ```
