### PR TITLE
fix: serialise Identity Store datetime fields that break all admin pages (#550)

### DIFF
--- a/amplify/backend/function/teamgetIdCGroups/src/index.py
+++ b/amplify/backend/function/teamgetIdCGroups/src/index.py
@@ -26,7 +26,10 @@ def list_idc_groups(IdentityStoreId):
         all_groups = []
         for page in paginator:
             all_groups.extend(page["Groups"])
-        return sorted(all_groups, key=itemgetter('DisplayName'))
+        return sorted(
+            [{"GroupId": group["GroupId"], "DisplayName": group["DisplayName"]} for group in all_groups],
+            key=itemgetter('DisplayName'),
+        )
     except ClientError as e:
         print(e.response['Error']['Message'])
 

--- a/amplify/backend/function/teamgetUsers/src/index.py
+++ b/amplify/backend/function/teamgetUsers/src/index.py
@@ -16,7 +16,7 @@ def get_identiy_store_id():
 
 
 sso_instance = get_identiy_store_id()
-        
+
 def list_idc_users(IdentityStoreId):
     try:
         client = boto3.client('identitystore')
@@ -25,7 +25,10 @@ def list_idc_users(IdentityStoreId):
         all_users = []
         for page in paginator:
             all_users.extend(page["Users"])
-        return sorted(all_users, key=itemgetter('UserName'))
+        return sorted(
+            [{"UserName": user["UserName"], "UserId": user["UserId"]} for user in all_users],
+            key=itemgetter('UserName'),
+        )
     except ClientError as e:
         print(e.response['Error']['Message'])
 


### PR DESCRIPTION
**Summary**

Fixes [#550](https://github.com/lindar-joy/mrq-iam-identity-center-team/issues/550) - All admin pages revert to a blank page with error fetching IdC Groups in the console.

Description of changes:
The identitystore list_groups and list_users APIs now return CreatedAt / UpdatedAt metadata, which boto3 deserialises into Python datetime objects. teamgetIdCGroups and teamgetUsers returned the raw API objects straight from their handlers, so when the Lambda runtime serialises the response it fails with:

[ERROR] Runtime.MarshalError: Unable to marshal response: Object of type datetime is not JSON serializable
Because this happens at the runtime's marshalling step (after the handler returns), the existing try/except ClientError can't catch it. The getIdCGroups / getUsers GraphQL queries then return an error, which the frontend swallows and renders as a blank page — affecting Settings, Eligibility, and Approvers (the pages that load IdC groups and users).

The fix projects each response to only the fields declared on the corresponding GraphQL types, which drops the non-serialisable datetime fields:

teamgetIdCGroups → [{ GroupId, DisplayName }] (matches type IdCGroups)
teamgetUsers → [{ UserName, UserId }] (matches type Users)

**Testing**

Deploy the updated functions (amplify push).
Sign in as a user in the TEAM admin group and open Administration → Settings — the page renders and the TEAM admin / auditor group dropdowns populate.
Open Eligibility policy and Approver policy — the group and user pickers populate.
Confirm no Runtime.MarshalError entries in the teamgetIdCGroups / teamgetUsers CloudWatch log groups.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.