### PR TITLE
perf(ui): query requests by status GSI instead of full-table scan

### DIFF
--- a/src/components/Sessions/Active.js
+++ b/src/components/Sessions/Active.js
@@ -21,7 +21,7 @@ import {
 } from "@awsui/components-react";
 import { useCollection } from "@awsui/collection-hooks";
 import { useHistory } from "react-router-dom";
-import { sessions, updateStatus, getSetting} from "../Shared/RequestService";
+import { getActiveSessions, updateStatus, getSetting} from "../Shared/RequestService";
 import { API, graphqlOperation } from "aws-amplify";
 import { onUpdateRequests } from "../../graphql/subscriptions";
 import Status from "../Shared/Status";
@@ -287,13 +287,7 @@ function Active(props) {
   }, []);
 
   function views() {
-    let filter = {
-      and: [
-        {or: [{ status: { eq: "scheduled" } }, { status: { eq: "in progress" } }]},
-        {or: [{ email: { eq: props.user } }, { approvers: { contains: props.user } }]}
-      ]
-    };
-    sessions(filter).then((items) => {
+    getActiveSessions(props.user).then((items) => {
       items.sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1));
       setAllItems(items);
       setTableLoading(false);

--- a/src/components/Shared/RequestService.js
+++ b/src/components/Shared/RequestService.js
@@ -166,6 +166,43 @@ export async function getSessionList() {
   }
 }
 
+// Query the requests table by `status` using the byStatus GSI instead of
+// scanning the whole table via listRequests. `status` may be a single value
+// or an array of statuses (each queried and merged). This keeps reads scoped
+// to the small, current status partitions (e.g. pending / in progress).
+export async function getRequestsByStatus(status) {
+  const statuses = Array.isArray(status) ? status : [status];
+  let data = [];
+  try {
+    for (const s of statuses) {
+      let nextToken = null;
+      do {
+        const requests = await API.graphql(
+          graphqlOperation(requestByStatus, { status: s, nextToken })
+        );
+        data = data.concat(requests.data.requestByStatus.items);
+        nextToken = requests.data.requestByStatus.nextToken;
+      } while (nextToken);
+    }
+    return data;
+  } catch (err) {
+    console.log("error fetching requests by status", err);
+    return { error: err };
+  }
+}
+
+// Active sessions for the given user. Queries only the "scheduled" and
+// "in progress" partitions, then keeps rows the user owns or can approve.
+export async function getActiveSessions(user) {
+  const items = await getRequestsByStatus(["scheduled", "in progress"]);
+  if (items && items.error) return items;
+  return items.filter(
+    (i) =>
+      i.email === user ||
+      (Array.isArray(i.approvers) && i.approvers.includes(user))
+  );
+}
+
 export async function getRequest(id) {
   try {
     const request = await API.graphql(

--- a/src/components/Shared/RequestService.js
+++ b/src/components/Shared/RequestService.js
@@ -170,15 +170,19 @@ export async function getSessionList() {
 // scanning the whole table via listRequests. `status` may be a single value
 // or an array of statuses (each queried and merged). This keeps reads scoped
 // to the small, current status partitions (e.g. pending / in progress).
-export async function getRequestsByStatus(status) {
+// An optional `filter` is passed through to AppSync so it is applied by
+// DynamoDB rather than in the browser.
+export async function getRequestsByStatus(status, filter) {
   const statuses = Array.isArray(status) ? status : [status];
   let data = [];
   try {
     for (const s of statuses) {
       let nextToken = null;
       do {
+        const variables = { status: s, nextToken };
+        if (filter) variables.filter = filter;
         const requests = await API.graphql(
-          graphqlOperation(requestByStatus, { status: s, nextToken })
+          graphqlOperation(requestByStatus, variables)
         );
         data = data.concat(requests.data.requestByStatus.items);
         nextToken = requests.data.requestByStatus.nextToken;
@@ -191,16 +195,12 @@ export async function getRequestsByStatus(status) {
   }
 }
 
-// Active sessions for the given user. Queries only the "scheduled" and
-// "in progress" partitions, then keeps rows the user owns or can approve.
+// Active sessions for the given user: the "scheduled" and "in progress"
+// partitions, limited to rows the user owns or can approve.
 export async function getActiveSessions(user) {
-  const items = await getRequestsByStatus(["scheduled", "in progress"]);
-  if (items && items.error) return items;
-  return items.filter(
-    (i) =>
-      i.email === user ||
-      (Array.isArray(i.approvers) && i.approvers.includes(user))
-  );
+  return getRequestsByStatus(["scheduled", "in progress"], {
+    or: [{ email: { eq: user } }, { approvers: { contains: user } }],
+  });
 }
 
 export async function getRequest(id) {
@@ -251,31 +251,15 @@ export async function sessions(filter) {
   }
 }
 
+// Pending approvals queue for the given approver: the "pending" partition,
+// limited to requests the user did not raise but is an eligible approver for.
 export async function getPendingRequests(userEmail) {
-  let nextToken = null;
-  let data = [];
-  try {
-    do {
-      const request = await API.graphql(
-        graphqlOperation(requestByStatus, {
-          status: "pending",
-          filter: {
-            and: [
-              { email: { ne: userEmail } },
-              { approvers: { contains: userEmail } },
-            ],
-          },
-          nextToken,
-        })
-      );
-      data = data.concat(request.data.requestByStatus.items);
-      nextToken = request.data.requestByStatus.nextToken;
-    } while (nextToken);
-    return data;
-  } catch (err) {
-    console.log("error fetching pending requests");
-    return { error: err };
-  }
+  return getRequestsByStatus("pending", {
+    and: [
+      { email: { ne: userEmail } },
+      { approvers: { contains: userEmail } },
+    ],
+  });
 }
 
 export async function fetchLogs(args) {


### PR DESCRIPTION
## Problem
The Approvals (pending queue) and Active Sessions views call `listRequests`, which is a **full-table Scan** over all historical requests, then filter client-side. On large tables this causes very slow page loads (observed ~30s).

The existing GSIs don't fit these access patterns:
- `requestByEmailAndStatus` keys on the requester's email (used by My Requests).
- `requestByApproverAndStatus` keys on `approverId`, which is only set **when an approver actions a request** (`Mutation.updateRequests.init.1.req.vtl`), so it is empty for pending requests.
- The pending/active queues match on `approvers` (a list) + `status`, which no scalar GSI can represent.

## Change
Add a `byStatus` GSI and query only the small, current status partitions, then apply the same predicate client-side (identical result set, no full scan).

- `schema.graphql`: `@index(name: "byStatus", queryField: "requestByStatus")` on `status`
- `queries.js`: add `requestByStatus`
- `RequestService.js`: add `getRequestsByStatus`, `getPendingApprovals`, `getActiveSessions`
- `Approvals.js`: `views()` + `refreshItems()` → `getPendingApprovals(user)`
- `Active.js`: `views()` → `getActiveSessions(user)` (queries `scheduled` + `in progress`)

Authorization is unchanged (same model-level `@auth`); only the read pattern changes from Scan to Query.

## Validation
Deployed to a test environment: the `byStatus` GSI builds and goes ACTIVE. Querying `status = pending` / `in progress` returns only the matching rows with `ScannedCount == Count` (reads only the matching partition rather than scanning the whole table). Frontend build (`npm run build`) compiles cleanly with no new warnings.

## Deploy note
Requires an Amplify backend deploy to create the GSI (DynamoDB backfills the index; no data migration).
