### PR TITLE
fix(handler): guard against non-INSERT/MODIFY events and handle missing data

### DIFF
--- a/amplify/backend/function/teamRouter/src/index.py
+++ b/amplify/backend/function/teamRouter/src/index.py
@@ -531,7 +531,10 @@ def process_record(data):
         print("Request not updated")
 
 def handler(event, context):
-    for record in event["Records"]:
-        data = record["dynamodb"]["NewImage"]
+    for record in event.get("Records", []):
+        if record.get("eventName") not in ("INSERT", "MODIFY"):
+            continue
+        data = record.get("dynamodb", {}).get("NewImage")
+        if not data:
+            continue
         process_record(data)
-


### PR DESCRIPTION
*Description of changes:*
handler assumes every DynamoDB stream record contains dynamodb.NewImage. For REMOVE events (and some stream configurations), NewImage can be missing, which will raise a KeyError and fail the whole batch (causing retries and potential duplicate processing). Guard on eventName and the presence of NewImage before calling process_record.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
