### PR TITLE
feat: add Amazon Athena as an alternative audit-log backend

### DIFF
--- a/amplify/backend/custom/cloudtrailLake/cloudtrailLake-cloudformation-template.json
+++ b/amplify/backend/custom/cloudtrailLake/cloudtrailLake-cloudformation-template.json
@@ -6,7 +6,7 @@
     },
     "CloudTrailAuditLogs":{
       "Type":"String",
-      "AllowedPattern": "(read_write|read|write|none|arn.*)"
+      "AllowedPattern": "(read_write|read|write|none|arn.*|athena://.*)"
     }
   },
   "Conditions":{
@@ -48,14 +48,6 @@
     },
     "CreateEventDataStore": {
       "Fn::Or": [
-        {
-          "Fn::Equals": [
-            "none",
-            {
-              "Ref": "CloudTrailAuditLogs"
-            }
-          ]
-        },
         {
           "Fn::Equals": [
             "read",

--- a/amplify/backend/function/teamgetLogs/parameters.json
+++ b/amplify/backend/function/teamgetLogs/parameters.json
@@ -1,0 +1,5 @@
+{
+    "AthenaTrailBucketArn": "",
+    "AthenaResultsBucketArn": "",
+    "AthenaTrailKmsKeyArn": ""
+}

--- a/amplify/backend/function/teamgetLogs/src/index.js
+++ b/amplify/backend/function/teamgetLogs/src/index.js
@@ -20,10 +20,18 @@ import {
   StartQueryCommand,
   DescribeQueryCommand,
 } from "@aws-sdk/client-cloudtrail"
+import {
+  AthenaClient,
+  StartQueryExecutionCommand,
+  GetQueryExecutionCommand,
+} from "@aws-sdk/client-athena"
 
 const { Sha256 } = crypto;
 const REGION = process.env.REGION;
-const EventDataStore = (process.env.EVENT_DATA_STORE).split("/").pop();
+const RAW_EVENT_DATA_STORE = process.env.EVENT_DATA_STORE;
+const IS_ATHENA = RAW_EVENT_DATA_STORE.startsWith("athena://");
+const IS_AUDIT_DISABLED = RAW_EVENT_DATA_STORE === "none";
+const EventDataStore = (IS_ATHENA || IS_AUDIT_DISABLED) ? RAW_EVENT_DATA_STORE : RAW_EVENT_DATA_STORE.split("/").pop();
 const GRAPHQL_ENDPOINT = process.env.API_TEAM_GRAPHQLAPIENDPOINTOUTPUT;
 
 // const {
@@ -33,6 +41,7 @@ const GRAPHQL_ENDPOINT = process.env.API_TEAM_GRAPHQLAPIENDPOINTOUTPUT;
 // } = require("@aws-sdk/client-cloudtrail");
 
 const client = new CloudTrailClient({ region: REGION });
+const athenaClient = new AthenaClient({ region: REGION });
 
 const query = /* GraphQL */ `
   mutation UpdateSessions(
@@ -151,11 +160,92 @@ const start_query = async (event) => {
   }
 };
 
+// athena:// URIs are validated by the CloudTrailAuditLogs AllowedPattern, but the
+// values interpolated into the query below (accountId, username, role, times) come
+// from a user-supplied request record, so they are escaped/validated explicitly.
+const escapeSqlLiteral = (value) => `'${String(value).replace(/'/g, "''")}'`;
+
+const parseAthenaTarget = (target) => {
+  const [workgroup, database, table] = target.slice("athena://".length).split("/");
+  return { workgroup, database, table };
+};
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const start_query_athena = async (event) => {
+  const startTime = event["startTime"]["S"];
+  const endTime = event["endTime"]["S"];
+  const username = event["username"]["S"].replace('idc_', '');
+  const accountId = event["accountId"]["S"];
+  const role = event["role"]["S"];
+
+  if (!/^\d{12}$/.test(accountId)) {
+    console.log("Error", new Error(`Invalid accountId for Athena query: ${accountId}`));
+    return;
+  }
+
+  const { workgroup, database, table } = parseAthenaTarget(EventDataStore);
+  const startDate = startTime.slice(0, 10).replace(/-/g, "/");
+  const endDate = endTime.slice(0, 10).replace(/-/g, "/");
+
+  try {
+    const input = {
+      QueryString: `SELECT eventid AS "eventID", eventname AS "eventName", eventsource AS "eventSource", eventtime AS "eventTime" FROM "${database}"."${table}" WHERE account = ${escapeSqlLiteral(accountId)} AND date BETWEEN ${escapeSqlLiteral(startDate)} AND ${escapeSqlLiteral(endDate)} AND eventtime > ${escapeSqlLiteral(startTime)} AND eventtime < ${escapeSqlLiteral(endTime)} AND lower(useridentity.principalid) LIKE ${escapeSqlLiteral(`%:${username}%`)} AND useridentity.sessioncontext.sessionissuer.arn LIKE ${escapeSqlLiteral(`%${role}%`)} AND recipientaccountid = ${escapeSqlLiteral(accountId)}`,
+      WorkGroup: workgroup,
+      QueryExecutionContext: { Database: database },
+    };
+    const command = new StartQueryExecutionCommand(input);
+    const response = await athenaClient.send(command);
+    return response.QueryExecutionId;
+  } catch (err) {
+    console.log("Error", err);
+  }
+};
+
+const get_query_status_athena = async (queryExecutionId) => {
+  try {
+    const input = { QueryExecutionId: queryExecutionId };
+    const command = new GetQueryExecutionCommand(input);
+    const response = await athenaClient.send(command);
+    return response.QueryExecution.Status.State;
+  } catch (err) {
+    console.log("Error", err);
+  }
+};
+
+const poll_query_athena = async (queryExecutionId) => {
+  let status = await get_query_status_athena(queryExecutionId);
+  while (status === "QUEUED" || status === "RUNNING") {
+    console.log(status);
+    await sleep(1000);
+    status = await get_query_status_athena(queryExecutionId);
+  }
+  return status;
+};
+
 export const handler = async (event) => {
   let data = event["Records"].pop()
   data = data["dynamodb"]["NewImage"]
   const id = data["id"]["S"]
   console.log("Event", data);
+
+  if (IS_AUDIT_DISABLED) {
+    console.log("CloudTrailAuditLogs is set to 'none'; skipping audit query for this session.");
+    return;
+  }
+
+  if (IS_ATHENA) {
+    const queryExecutionId = await start_query_athena(data);
+    const status = await poll_query_athena(queryExecutionId);
+    if (status === "SUCCEEDED") {
+      console.log("Athena query succeeded - queryExecutionId:", queryExecutionId);
+      const response = await updateItem(id, queryExecutionId);
+      return response;
+    }
+    console.log("Athena query did not succeed - status:", status);
+    return;
+  }
+
   const queryId = await start_query(data);
   let status = await get_query_status(queryId);
   while (status) {

--- a/amplify/backend/function/teamgetLogs/src/package.json
+++ b/amplify/backend/function/teamgetLogs/src/package.json
@@ -13,6 +13,7 @@
   },
   "author": "",
   "dependencies": {
+    "@aws-sdk/client-athena": "^3.777.0",
     "@aws-sdk/client-cloudtrail": "^3.777.0",
     "@aws-crypto/sha256-js": "^2.0.1",
     "@aws-sdk/credential-provider-node": "^3.76.0",

--- a/amplify/backend/function/teamgetLogs/teamgetLogs-cloudformation-template.json
+++ b/amplify/backend/function/teamgetLogs/teamgetLogs-cloudformation-template.json
@@ -26,6 +26,18 @@
     "apiteamGraphQLAPIEndpointOutput": {
       "Type": "String",
       "Default": "apiteamGraphQLAPIEndpointOutput"
+    },
+    "AthenaTrailBucketArn": {
+      "Type": "String",
+      "Default": ""
+    },
+    "AthenaResultsBucketArn": {
+      "Type": "String",
+      "Default": ""
+    },
+    "AthenaTrailKmsKeyArn": {
+      "Type": "String",
+      "Default": ""
     }
   },
   "Conditions": {
@@ -35,6 +47,30 @@
           "Ref": "env"
         },
         "NONE"
+      ]
+    },
+    "IsAthenaEnabled": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "AthenaTrailBucketArn"
+            },
+            ""
+          ]
+        }
+      ]
+    },
+    "IsAthenaTrailKmsKeySet": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "AthenaTrailKmsKeyArn"
+            },
+            ""
+          ]
+        }
       ]
     }
   },
@@ -360,6 +396,179 @@
               ],
               "Resource": [
                 "*"
+              ],
+              "Effect": "Allow"
+            }
+          ]
+        },
+        "Roles": [
+          {
+            "Ref": "LambdaExecutionRole"
+          }
+        ]
+      },
+      "DependsOn": "LambdaExecutionRole"
+    },
+    "AthenaExecutionPolicy": {
+      "Condition": "IsAthenaEnabled",
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "athena-execution-policy",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "athena:StartQueryExecution",
+                "athena:GetQueryExecution"
+              ],
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "arn:${AWS::Partition}:athena:${AWS::Region}:${AWS::AccountId}:workgroup/${workgroup}",
+                    {
+                      "workgroup": {
+                        "Fn::Select": [
+                          2,
+                          {
+                            "Fn::Split": [
+                              "/",
+                              {
+                                "Ref": "customcloudtrailLakeEventDataStoreOutput"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "Effect": "Allow"
+            },
+            {
+              "Action": [
+                "glue:GetTable",
+                "glue:GetDatabase",
+                "glue:GetPartitions"
+              ],
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:catalog"
+                },
+                {
+                  "Fn::Sub": [
+                    "arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/${database}",
+                    {
+                      "database": {
+                        "Fn::Select": [
+                          3,
+                          {
+                            "Fn::Split": [
+                              "/",
+                              {
+                                "Ref": "customcloudtrailLakeEventDataStoreOutput"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Fn::Sub": [
+                    "arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:table/${database}/${table}",
+                    {
+                      "database": {
+                        "Fn::Select": [
+                          3,
+                          {
+                            "Fn::Split": [
+                              "/",
+                              {
+                                "Ref": "customcloudtrailLakeEventDataStoreOutput"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "table": {
+                        "Fn::Select": [
+                          4,
+                          {
+                            "Fn::Split": [
+                              "/",
+                              {
+                                "Ref": "customcloudtrailLakeEventDataStoreOutput"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "Effect": "Allow"
+            },
+            {
+              "Action": [
+                "s3:GetObject",
+                "s3:ListBucket"
+              ],
+              "Resource": [
+                {
+                  "Ref": "AthenaTrailBucketArn"
+                },
+                {
+                  "Fn::Sub": "${AthenaTrailBucketArn}/*"
+                }
+              ],
+              "Effect": "Allow"
+            },
+            {
+              "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:ListBucket"
+              ],
+              "Resource": [
+                {
+                  "Ref": "AthenaResultsBucketArn"
+                },
+                {
+                  "Fn::Sub": "${AthenaResultsBucketArn}/*"
+                }
+              ],
+              "Effect": "Allow"
+            }
+          ]
+        },
+        "Roles": [
+          {
+            "Ref": "LambdaExecutionRole"
+          }
+        ]
+      },
+      "DependsOn": "LambdaExecutionRole"
+    },
+    "AthenaTrailKmsPolicy": {
+      "Condition": "IsAthenaTrailKmsKeySet",
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "athena-trail-kms-policy",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "kms:Decrypt"
+              ],
+              "Resource": [
+                {
+                  "Ref": "AthenaTrailKmsKeyArn"
+                }
               ],
               "Effect": "Allow"
             }

--- a/amplify/backend/function/teamqueryLogs/parameters.json
+++ b/amplify/backend/function/teamqueryLogs/parameters.json
@@ -1,0 +1,5 @@
+{
+    "AthenaTrailBucketArn": "",
+    "AthenaResultsBucketArn": "",
+    "AthenaTrailKmsKeyArn": ""
+}

--- a/amplify/backend/function/teamqueryLogs/src/index.js
+++ b/amplify/backend/function/teamqueryLogs/src/index.js
@@ -2,13 +2,21 @@
 //  This AWS Content is provided subject to the terms of the AWS Customer Agreement available at
 //  http: // aws.amazon.com/agreement or other written agreement between Customer and either
 //  Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
-const EventDataStore = (process.env.EVENT_DATA_STORE).split("/").pop();
+const RAW_EVENT_DATA_STORE = process.env.EVENT_DATA_STORE;
 const REGION = process.env.REGION;
+const IS_ATHENA = RAW_EVENT_DATA_STORE.startsWith("athena://");
+const IS_AUDIT_DISABLED = RAW_EVENT_DATA_STORE === "none";
+const EventDataStore = (IS_ATHENA || IS_AUDIT_DISABLED) ? RAW_EVENT_DATA_STORE : RAW_EVENT_DATA_STORE.split("/").pop();
 const {
     CloudTrailClient,
     paginateGetQueryResults,
   } = require("@aws-sdk/client-cloudtrail");
   const client = new CloudTrailClient({ region: REGION });
+const {
+    AthenaClient,
+    paginateGetQueryResults: paginateAthenaQueryResults,
+  } = require("@aws-sdk/client-athena");
+  const athenaClient = new AthenaClient({ region: REGION });
 
 
 const get_query = async (queryId) => {
@@ -40,8 +48,47 @@ try {
     console.log("Error", err);
 }
 };
-  
+
+// Athena's GetQueryResults returns a header row as the first row of the first
+// page only (never on subsequent NextToken pages) - the Lake API has no such row.
+const get_query_athena = async (queryExecutionId) => {
+try {
+    const output = [];
+    const input = {
+    QueryExecutionId: queryExecutionId,
+    };
+    const paginatorConfig = {
+    client: new AthenaClient({ region: REGION }),
+    };
+    const paginator = paginateAthenaQueryResults(paginatorConfig, input);
+    let isFirstPage = true;
+    for await (const page of paginator) {
+    const columns = page.ResultSet.ResultSetMetadata.ColumnInfo.map((c) => c.Name);
+    const rows = isFirstPage ? page.ResultSet.Rows.slice(1) : page.ResultSet.Rows;
+    isFirstPage = false;
+    for (const row of rows) {
+        const logs = {};
+        row.Data.forEach((cell, index) => {
+        logs[columns[index]] = cell.VarCharValue;
+        });
+        output.push(logs);
+    }
+    }
+    console.log(output);
+    return output;
+} catch (err) {
+    console.log("Error", err);
+}
+};
+
 exports.handler = async (event) => {
     const queryId = event["arguments"]["queryId"]
+    if (IS_AUDIT_DISABLED || !queryId) {
+      console.log("CloudTrailAuditLogs is set to 'none' or no query was recorded for this session; returning no logs.");
+      return [];
+    }
+    if (IS_ATHENA) {
+      return get_query_athena(queryId);
+    }
     return get_query(queryId);
 };

--- a/amplify/backend/function/teamqueryLogs/src/package.json
+++ b/amplify/backend/function/teamqueryLogs/src/package.json
@@ -12,6 +12,7 @@
   },
   "author": "",
   "dependencies": {
+    "@aws-sdk/client-athena": "^3.777.0",
     "@aws-sdk/client-cloudtrail": "^3.777.0"
   }
 }

--- a/amplify/backend/function/teamqueryLogs/teamqueryLogs-cloudformation-template.json
+++ b/amplify/backend/function/teamqueryLogs/teamqueryLogs-cloudformation-template.json
@@ -18,6 +18,18 @@
     },
     "customcloudtrailLakeEventDataStoreOutput": {
       "Type": "String"
+    },
+    "AthenaTrailBucketArn": {
+      "Type": "String",
+      "Default": ""
+    },
+    "AthenaResultsBucketArn": {
+      "Type": "String",
+      "Default": ""
+    },
+    "AthenaTrailKmsKeyArn": {
+      "Type": "String",
+      "Default": ""
     }
   },
   "Conditions": {
@@ -27,6 +39,18 @@
           "Ref": "env"
         },
         "NONE"
+      ]
+    },
+    "IsAthenaEnabled": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "AthenaTrailBucketArn"
+            },
+            ""
+          ]
+        }
       ]
     }
   },
@@ -187,6 +211,132 @@
               ],
               "Resource": [
                 "*"
+              ],
+              "Effect": "Allow"
+            }
+          ]
+        },
+        "Roles": [
+          {
+            "Ref": "LambdaExecutionRole"
+          }
+        ]
+      },
+      "DependsOn": "LambdaExecutionRole"
+    },
+    "AthenaResultsPolicy": {
+      "Condition": "IsAthenaEnabled",
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "athena-results-policy",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "athena:GetQueryResults"
+              ],
+              "Resource": [
+                {
+                  "Fn::Sub": [
+                    "arn:${AWS::Partition}:athena:${AWS::Region}:${AWS::AccountId}:workgroup/${workgroup}",
+                    {
+                      "workgroup": {
+                        "Fn::Select": [
+                          2,
+                          {
+                            "Fn::Split": [
+                              "/",
+                              {
+                                "Ref": "customcloudtrailLakeEventDataStoreOutput"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "Effect": "Allow"
+            },
+            {
+              "Action": [
+                "glue:GetTable",
+                "glue:GetDatabase"
+              ],
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:catalog"
+                },
+                {
+                  "Fn::Sub": [
+                    "arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/${database}",
+                    {
+                      "database": {
+                        "Fn::Select": [
+                          3,
+                          {
+                            "Fn::Split": [
+                              "/",
+                              {
+                                "Ref": "customcloudtrailLakeEventDataStoreOutput"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Fn::Sub": [
+                    "arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:table/${database}/${table}",
+                    {
+                      "database": {
+                        "Fn::Select": [
+                          3,
+                          {
+                            "Fn::Split": [
+                              "/",
+                              {
+                                "Ref": "customcloudtrailLakeEventDataStoreOutput"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "table": {
+                        "Fn::Select": [
+                          4,
+                          {
+                            "Fn::Split": [
+                              "/",
+                              {
+                                "Ref": "customcloudtrailLakeEventDataStoreOutput"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "Effect": "Allow"
+            },
+            {
+              "Action": [
+                "s3:GetObject",
+                "s3:ListBucket"
+              ],
+              "Resource": [
+                {
+                  "Ref": "AthenaResultsBucketArn"
+                },
+                {
+                  "Fn::Sub": "${AthenaResultsBucketArn}/*"
+                }
               ],
               "Effect": "Allow"
             }

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -39,6 +39,9 @@ if [ -z "$SECRET_NAME" ]; then
         --parameter-overrides \
           Login=$IDC_LOGIN_URL \
           CloudTrailAuditLogs=$CLOUDTRAIL_AUDIT_LOGS \
+          AthenaTrailBucketArn="$ATHENA_TRAIL_BUCKET_ARN" \
+          AthenaResultsBucketArn="$ATHENA_RESULTS_BUCKET_ARN" \
+          AthenaTrailKmsKeyArn="$ATHENA_TRAIL_KMS_KEY_ARN" \
           teamAdminGroup="$TEAM_ADMIN_GROUP" \
           teamAuditGroup="$TEAM_AUDITOR_GROUP" \
           tags="$TAGS" \
@@ -53,6 +56,9 @@ if [ -z "$SECRET_NAME" ]; then
         --parameter-overrides \
           Login=$IDC_LOGIN_URL \
           CloudTrailAuditLogs=$CLOUDTRAIL_AUDIT_LOGS \
+          AthenaTrailBucketArn="$ATHENA_TRAIL_BUCKET_ARN" \
+          AthenaResultsBucketArn="$ATHENA_RESULTS_BUCKET_ARN" \
+          AthenaTrailKmsKeyArn="$ATHENA_TRAIL_KMS_KEY_ARN" \
           teamAdminGroup="$TEAM_ADMIN_GROUP" \
           teamAuditGroup="$TEAM_AUDITOR_GROUP" \
           tags="$TAGS" \
@@ -68,6 +74,9 @@ if [ -z "$SECRET_NAME" ]; then
         --parameter-overrides \
           Login=$IDC_LOGIN_URL \
           CloudTrailAuditLogs=$CLOUDTRAIL_AUDIT_LOGS \
+          AthenaTrailBucketArn="$ATHENA_TRAIL_BUCKET_ARN" \
+          AthenaResultsBucketArn="$ATHENA_RESULTS_BUCKET_ARN" \
+          AthenaTrailKmsKeyArn="$ATHENA_TRAIL_KMS_KEY_ARN" \
           teamAdminGroup="$TEAM_ADMIN_GROUP" \
           teamAuditGroup="$TEAM_AUDITOR_GROUP" \
           teamAccount="$TEAM_ACCOUNT" \
@@ -81,6 +90,9 @@ if [ -z "$SECRET_NAME" ]; then
         --parameter-overrides \
           Login=$IDC_LOGIN_URL \
           CloudTrailAuditLogs=$CLOUDTRAIL_AUDIT_LOGS \
+          AthenaTrailBucketArn="$ATHENA_TRAIL_BUCKET_ARN" \
+          AthenaResultsBucketArn="$ATHENA_RESULTS_BUCKET_ARN" \
+          AthenaTrailKmsKeyArn="$ATHENA_TRAIL_KMS_KEY_ARN" \
           teamAdminGroup="$TEAM_ADMIN_GROUP" \
           teamAuditGroup="$TEAM_AUDITOR_GROUP" \
           teamAccount="$TEAM_ACCOUNT" \
@@ -97,6 +109,9 @@ else
         --parameter-overrides \
           Login=$IDC_LOGIN_URL \
           CloudTrailAuditLogs=$CLOUDTRAIL_AUDIT_LOGS \
+          AthenaTrailBucketArn="$ATHENA_TRAIL_BUCKET_ARN" \
+          AthenaResultsBucketArn="$ATHENA_RESULTS_BUCKET_ARN" \
+          AthenaTrailKmsKeyArn="$ATHENA_TRAIL_KMS_KEY_ARN" \
           teamAdminGroup="$TEAM_ADMIN_GROUP" \
           teamAuditGroup="$TEAM_AUDITOR_GROUP" \
           tags="$TAGS" \
@@ -113,6 +128,9 @@ else
         --parameter-overrides \
           Login=$IDC_LOGIN_URL \
           CloudTrailAuditLogs=$CLOUDTRAIL_AUDIT_LOGS \
+          AthenaTrailBucketArn="$ATHENA_TRAIL_BUCKET_ARN" \
+          AthenaResultsBucketArn="$ATHENA_RESULTS_BUCKET_ARN" \
+          AthenaTrailKmsKeyArn="$ATHENA_TRAIL_KMS_KEY_ARN" \
           teamAdminGroup="$TEAM_ADMIN_GROUP" \
           teamAuditGroup="$TEAM_AUDITOR_GROUP" \
           tags="$TAGS" \
@@ -130,6 +148,9 @@ else
         --parameter-overrides \
           Login=$IDC_LOGIN_URL \
           CloudTrailAuditLogs=$CLOUDTRAIL_AUDIT_LOGS \
+          AthenaTrailBucketArn="$ATHENA_TRAIL_BUCKET_ARN" \
+          AthenaResultsBucketArn="$ATHENA_RESULTS_BUCKET_ARN" \
+          AthenaTrailKmsKeyArn="$ATHENA_TRAIL_KMS_KEY_ARN" \
           teamAdminGroup="$TEAM_ADMIN_GROUP" \
           teamAuditGroup="$TEAM_AUDITOR_GROUP" \
           teamAccount="$TEAM_ACCOUNT" \
@@ -145,6 +166,9 @@ else
         --parameter-overrides \
           Login=$IDC_LOGIN_URL \
           CloudTrailAuditLogs=$CLOUDTRAIL_AUDIT_LOGS \
+          AthenaTrailBucketArn="$ATHENA_TRAIL_BUCKET_ARN" \
+          AthenaResultsBucketArn="$ATHENA_RESULTS_BUCKET_ARN" \
+          AthenaTrailKmsKeyArn="$ATHENA_TRAIL_KMS_KEY_ARN" \
           teamAdminGroup="$TEAM_ADMIN_GROUP" \
           teamAuditGroup="$TEAM_AUDITOR_GROUP" \
           teamAccount="$TEAM_ACCOUNT" \

--- a/deployment/parameters-mgmt-template.sh
+++ b/deployment/parameters-mgmt-template.sh
@@ -20,6 +20,11 @@ TEAM_AUDITOR_GROUP="team_auditor_group_name"
 TAGS="project=iam-identity-center-team environment=prod"
 CLOUDTRAIL_AUDIT_LOGS=read_write
 SECRET_NAME=TEAM-IDC-APP
+
+# Uncomment the next three lines only if CLOUDTRAIL_AUDIT_LOGS is an athena://<workgroup>/<database>/<table> URI
+# ATHENA_TRAIL_BUCKET_ARN=arn:aws:s3:::my-org-trail-bucket
+# ATHENA_RESULTS_BUCKET_ARN=arn:aws:s3:::my-athena-results-bucket
+# ATHENA_TRAIL_KMS_KEY_ARN=arn:aws:kms:us-east-1:123456789101:key/00000000-0000-0000-0000-000000000000
 # Uncomment the next line only if you have a custom domain
 # UI_DOMAIN=portal.teamtest.online
 

--- a/deployment/parameters-template.sh
+++ b/deployment/parameters-template.sh
@@ -24,6 +24,11 @@ CLOUDTRAIL_AUDIT_LOGS=arn:aws:cloudtrail:us-east-1:123456789101:eventdatastore/e
 SECRET_NAME=TEAM-IDC-APP
 CACHE_TTL=604800
 
+# Uncomment the next three lines only if CLOUDTRAIL_AUDIT_LOGS is an athena://<workgroup>/<database>/<table> URI
+# ATHENA_TRAIL_BUCKET_ARN=arn:aws:s3:::my-org-trail-bucket
+# ATHENA_RESULTS_BUCKET_ARN=arn:aws:s3:::my-athena-results-bucket
+# ATHENA_TRAIL_KMS_KEY_ARN=arn:aws:kms:us-east-1:123456789101:key/00000000-0000-0000-0000-000000000000
+
 # Uncomment the next line only if you have a custom domain
 # UI_DOMAIN=portal.teamtest.online
 

--- a/deployment/template.yml
+++ b/deployment/template.yml
@@ -6,8 +6,20 @@ Parameters:
     Description: IAM IDC Login URL
   CloudTrailAuditLogs:
     Type: "String"
-    AllowedPattern: "(read_write|read|write|none|arn.*)"
-    Description: Which events should be logged on the TEAM Application Cloudtrail Lake EventDataStore.  Acceptable values are "read","write","read_write", and "none".  You may also enter the arn of an existing Cloudtrail Lake EDS.
+    AllowedPattern: "(read_write|read|write|none|arn.*|athena://.*)"
+    Description: Which events should be logged on the TEAM Application Cloudtrail Lake EventDataStore.  Acceptable values are "read","write","read_write", and "none".  You may also enter the arn of an existing Cloudtrail Lake EDS, or an athena://<workgroup>/<database>/<table> URI to query an existing organization trail via Athena instead of Cloudtrail Lake.
+  AthenaTrailBucketArn:
+    Type: String
+    Description: ARN of the S3 bucket holding the organization Cloudtrail trail Athena will query. Required only when CloudTrailAuditLogs is an athena:// URI.
+    Default: ""
+  AthenaResultsBucketArn:
+    Type: String
+    Description: ARN of the S3 bucket configured as the Athena workgroup's query results location. Required only when CloudTrailAuditLogs is an athena:// URI.
+    Default: ""
+  AthenaTrailKmsKeyArn:
+    Type: String
+    Description: ARN of the KMS key used to encrypt the Cloudtrail trail bucket, if any. Only needed when the trail bucket is CMK-encrypted.
+    Default: ""
   teamAdminGroup:
     Type: String
     Description: TEAM application Admin group
@@ -160,6 +172,12 @@ Resources:
             - IsEmptyCloudTrailAuditLogs
             - "read_write"
             - !Ref CloudTrailAuditLogs
+        - Name: ATHENA_TRAIL_BUCKET_ARN
+          Value: !Ref AthenaTrailBucketArn
+        - Name: ATHENA_RESULTS_BUCKET_ARN
+          Value: !Ref AthenaResultsBucketArn
+        - Name: ATHENA_TRAIL_KMS_KEY_ARN
+          Value: !Ref AthenaTrailKmsKeyArn
         - Name: TEAM_ADMIN_GROUP
           Value: !Ref teamAdminGroup
         - Name: TEAM_AUDITOR_GROUP

--- a/deployment/update.sh
+++ b/deployment/update.sh
@@ -36,6 +36,9 @@ if [ -z "$SECRET_NAME" ]; then
         --parameter-overrides \
           Login=$IDC_LOGIN_URL \
           CloudTrailAuditLogs=$CLOUDTRAIL_AUDIT_LOGS \
+          AthenaTrailBucketArn="$ATHENA_TRAIL_BUCKET_ARN" \
+          AthenaResultsBucketArn="$ATHENA_RESULTS_BUCKET_ARN" \
+          AthenaTrailKmsKeyArn="$ATHENA_TRAIL_KMS_KEY_ARN" \
           teamAdminGroup="$TEAM_ADMIN_GROUP" \
           teamAuditGroup="$TEAM_AUDITOR_GROUP" \
           tags="$TAGS" \
@@ -50,6 +53,9 @@ if [ -z "$SECRET_NAME" ]; then
         --parameter-overrides \
           Login=$IDC_LOGIN_URL \
           CloudTrailAuditLogs=$CLOUDTRAIL_AUDIT_LOGS \
+          AthenaTrailBucketArn="$ATHENA_TRAIL_BUCKET_ARN" \
+          AthenaResultsBucketArn="$ATHENA_RESULTS_BUCKET_ARN" \
+          AthenaTrailKmsKeyArn="$ATHENA_TRAIL_KMS_KEY_ARN" \
           teamAdminGroup="$TEAM_ADMIN_GROUP" \
           teamAuditGroup="$TEAM_AUDITOR_GROUP" \
           tags="$TAGS" \
@@ -65,6 +71,9 @@ if [ -z "$SECRET_NAME" ]; then
         --parameter-overrides \
           Login=$IDC_LOGIN_URL \
           CloudTrailAuditLogs=$CLOUDTRAIL_AUDIT_LOGS \
+          AthenaTrailBucketArn="$ATHENA_TRAIL_BUCKET_ARN" \
+          AthenaResultsBucketArn="$ATHENA_RESULTS_BUCKET_ARN" \
+          AthenaTrailKmsKeyArn="$ATHENA_TRAIL_KMS_KEY_ARN" \
           teamAdminGroup="$TEAM_ADMIN_GROUP" \
           teamAuditGroup="$TEAM_AUDITOR_GROUP" \
           teamAccount="$TEAM_ACCOUNT" \
@@ -78,6 +87,9 @@ if [ -z "$SECRET_NAME" ]; then
         --parameter-overrides \
           Login=$IDC_LOGIN_URL \
           CloudTrailAuditLogs=$CLOUDTRAIL_AUDIT_LOGS \
+          AthenaTrailBucketArn="$ATHENA_TRAIL_BUCKET_ARN" \
+          AthenaResultsBucketArn="$ATHENA_RESULTS_BUCKET_ARN" \
+          AthenaTrailKmsKeyArn="$ATHENA_TRAIL_KMS_KEY_ARN" \
           teamAdminGroup="$TEAM_ADMIN_GROUP" \
           teamAuditGroup="$TEAM_AUDITOR_GROUP" \
           teamAccount="$TEAM_ACCOUNT" \
@@ -96,6 +108,9 @@ else
         --parameter-overrides \
           Login=$IDC_LOGIN_URL \
           CloudTrailAuditLogs=$CLOUDTRAIL_AUDIT_LOGS \
+          AthenaTrailBucketArn="$ATHENA_TRAIL_BUCKET_ARN" \
+          AthenaResultsBucketArn="$ATHENA_RESULTS_BUCKET_ARN" \
+          AthenaTrailKmsKeyArn="$ATHENA_TRAIL_KMS_KEY_ARN" \
           teamAdminGroup="$TEAM_ADMIN_GROUP" \
           teamAuditGroup="$TEAM_AUDITOR_GROUP" \
           tags="$TAGS" \
@@ -112,6 +127,9 @@ else
         --parameter-overrides \
           Login=$IDC_LOGIN_URL \
           CloudTrailAuditLogs=$CLOUDTRAIL_AUDIT_LOGS \
+          AthenaTrailBucketArn="$ATHENA_TRAIL_BUCKET_ARN" \
+          AthenaResultsBucketArn="$ATHENA_RESULTS_BUCKET_ARN" \
+          AthenaTrailKmsKeyArn="$ATHENA_TRAIL_KMS_KEY_ARN" \
           teamAdminGroup="$TEAM_ADMIN_GROUP" \
           teamAuditGroup="$TEAM_AUDITOR_GROUP" \
           tags="$TAGS" \
@@ -129,6 +147,9 @@ else
         --parameter-overrides \
           Login=$IDC_LOGIN_URL \
           CloudTrailAuditLogs=$CLOUDTRAIL_AUDIT_LOGS \
+          AthenaTrailBucketArn="$ATHENA_TRAIL_BUCKET_ARN" \
+          AthenaResultsBucketArn="$ATHENA_RESULTS_BUCKET_ARN" \
+          AthenaTrailKmsKeyArn="$ATHENA_TRAIL_KMS_KEY_ARN" \
           teamAdminGroup="$TEAM_ADMIN_GROUP" \
           teamAuditGroup="$TEAM_AUDITOR_GROUP" \
           teamAccount="$TEAM_ACCOUNT" \
@@ -144,6 +165,9 @@ else
         --parameter-overrides \
           Login=$IDC_LOGIN_URL \
           CloudTrailAuditLogs=$CLOUDTRAIL_AUDIT_LOGS \
+          AthenaTrailBucketArn="$ATHENA_TRAIL_BUCKET_ARN" \
+          AthenaResultsBucketArn="$ATHENA_RESULTS_BUCKET_ARN" \
+          AthenaTrailKmsKeyArn="$ATHENA_TRAIL_KMS_KEY_ARN" \
           teamAdminGroup="$TEAM_ADMIN_GROUP" \
           teamAuditGroup="$TEAM_AUDITOR_GROUP" \
           customRepository="Yes" \

--- a/docs/docs/deployment/configuration/athena.md
+++ b/docs/docs/deployment/configuration/athena.md
@@ -1,0 +1,135 @@
+---
+layout: default
+title: Athena audit log configuration
+nav_order: 9
+parent: Configuration
+grand_parent: Solution deployment
+---
+
+# Athena audit log configuration
+
+> AWS closed CloudTrail Lake to new customers on May 31, 2026. If you already have a CloudTrail Lake event data store, you do not need this page - continue using `CLOUDTRAIL_AUDIT_LOGS=read`/`write`/`read_write`/an event data store ARN as before. This page is for new TEAM deployments that query an existing AWS Organizations CloudTrail trail via Amazon Athena instead.
+{: .important}
+
+TEAM does not create the Glue table, crawler, or Athena workgroup for you. You create these once, before deploying TEAM, against the S3 bucket your organization trail already delivers logs to.
+
+## 1. Create the Glue table
+
+Run this once, in the account where your organization trail's log bucket lives (often a dedicated log-archive account). Replace `<trail-bucket>`, `<database>`, and `<table>` with your own values, and adjust the `storage.location.template` to match your trail's S3 key prefix.
+
+```sql
+CREATE EXTERNAL TABLE <database>.<table> (
+  eventversion STRING,
+  useridentity STRUCT<
+    type: STRING,
+    principalid: STRING,
+    arn: STRING,
+    accountid: STRING,
+    invokedby: STRING,
+    accesskeyid: STRING,
+    userName: STRING,
+    sessioncontext: STRUCT<
+      attributes: STRUCT<
+        mfaauthenticated: STRING,
+        creationdate: STRING>,
+      sessionissuer: STRUCT<
+        type: STRING,
+        principalId: STRING,
+        arn: STRING,
+        accountId: STRING,
+        userName: STRING>>>,
+  eventtime STRING,
+  eventsource STRING,
+  eventname STRING,
+  awsregion STRING,
+  sourceipaddress STRING,
+  useragent STRING,
+  errorcode STRING,
+  errormessage STRING,
+  requestparameters STRING,
+  responseelements STRING,
+  additionaleventdata STRING,
+  requestid STRING,
+  eventid STRING,
+  resources ARRAY<STRUCT<
+    ARN: STRING,
+    accountId: STRING,
+    type: STRING>>,
+  eventtype STRING,
+  apiversion STRING,
+  readonly STRING,
+  recipientaccountid STRING,
+  serviceeventdetails STRING,
+  sharedeventid STRING,
+  vpcendpointid STRING
+)
+PARTITIONED BY (account STRING, region STRING, date STRING)
+ROW FORMAT SERDE 'com.amazon.emr.hive.serde.CloudTrailSerde'
+STORED AS INPUTFORMAT 'com.amazon.emr.cloudtrail.CloudTrailInputFormat'
+OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
+LOCATION 's3://<trail-bucket>/AWSLogs/'
+TBLPROPERTIES (
+  'projection.enabled' = 'true',
+  'projection.account.type' = 'injected',
+  'projection.region.type' = 'enum',
+  'projection.region.values' = 'us-east-1,us-east-2,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-central-1,ap-southeast-1,ap-southeast-2,ap-northeast-1',
+  'projection.date.type' = 'date',
+  'projection.date.range' = '2023/01/01,NOW',
+  'projection.date.format' = 'yyyy/MM/dd',
+  'projection.date.interval' = '1',
+  'projection.date.interval.unit' = 'DAYS',
+  'storage.location.template' = 's3://<trail-bucket>/AWSLogs/${account}/CloudTrail/${region}/${date}'
+)
+```
+
+> Adjust `projection.region.values` to the regions your organization actually operates in - a narrower list means Athena enumerates fewer region partitions per query. If your trail bucket key layout includes an AWS Organizations ID segment (`AWSLogs/o-xxxxxxxxxx/<account>/CloudTrail/...`), add it to `LOCATION` and `storage.location.template` accordingly.
+{: .note}
+
+TEAM's session lookup filters on `account` and `date` (the session's target account and time window) but has no region for a session, so it cannot prune the `region` partition - Athena scans every enumerated region's partition for the matched account/date. This is still bounded and cheap; it is not a full-history scan.
+
+## 2. Create (or choose) an Athena workgroup
+
+The workgroup must have a query result location configured (**Settings → Query result location** in the Athena console, or `ResultConfiguration.OutputLocation` via the API). TEAM's Lambda functions rely on the workgroup's default result location - they do not pass an explicit `ResultConfiguration`, so if the workgroup has none configured, queries will fail.
+
+## 3. Cross-account access
+
+If the trail bucket lives in a different account than TEAM (for example, a log-archive account), that bucket's policy must grant the TEAM Lambda execution role read access:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::<team-account-id>:role/teamapplicationLambdaRole5fbe17a6-<env>"
+      },
+      "Action": ["s3:GetObject", "s3:ListBucket"],
+      "Resource": [
+        "arn:aws:s3:::<trail-bucket>",
+        "arn:aws:s3:::<trail-bucket>/*"
+      ]
+    }
+  ]
+}
+```
+
+If the trail bucket is encrypted with a customer-managed KMS key, grant the same role `kms:Decrypt` on that key (via a key policy grant or `aws kms create-grant`).
+
+## 4. Set the TEAM deployment parameters
+
+In `deployment/parameters.sh`, set:
+
+```sh
+CLOUDTRAIL_AUDIT_LOGS=athena://<workgroup>/<database>/<table>
+ATHENA_TRAIL_BUCKET_ARN=arn:aws:s3:::<trail-bucket>
+ATHENA_RESULTS_BUCKET_ARN=arn:aws:s3:::<athena-results-bucket>
+# Only if the trail bucket is encrypted with a customer-managed KMS key:
+ATHENA_TRAIL_KMS_KEY_ARN=arn:aws:kms:<region>:<account-id>:key/<key-id>
+```
+
+`ATHENA_TRAIL_BUCKET_ARN` and `ATHENA_RESULTS_BUCKET_ARN` scope the IAM permissions TEAM's Lambda execution roles get - they are only used for policy generation, not passed to Athena at query time. TEAM does not create the workgroup, the Glue table, or run any DDL on your behalf; it only queries the table you created in step 1.
+
+## Cost
+
+Athena charges per TB of data scanned per query. Partition projection (configured above) is what keeps a single session lookup scoped to the megabytes of logs for one account over one day's date partitions, rather than scanning your entire trail history. Without correctly configured partitioning, a single "what did this user do" lookup could scan your organization's entire CloudTrail history and cost accordingly - verify partition projection is working (`EXPLAIN` the query, or check *Data scanned* on a test query in the Athena console) before relying on this in production.

--- a/docs/docs/deployment/deployment_process.md
+++ b/docs/docs/deployment/deployment_process.md
@@ -54,7 +54,11 @@ Update the parameters in the **parameters.sh** file as follows:
 - **TEAM_ACCOUNT_PROFILE** - Named profile for TEAM Application deployment Account
 - **TEAM_ADMIN_GROUP** - Name of IAM Identity Center group for TEAM administrators
 - **TEAM_AUDITOR_GROUP** - Name of IAM Identity Center group for TEAM auditors
-- **CLOUDTRAIL_AUDIT_LOGS** - ARN of organization CloudTrail Lake event datastore
+- **CLOUDTRAIL_AUDIT_LOGS** - Which audit log backend TEAM should use. Accepts:
+  - `read`, `write`, or `read_write` - TEAM creates and manages its own CloudTrail Lake event data store
+  - the ARN of an existing CloudTrail Lake event data store
+  - `none` - audit log querying is disabled
+  - `athena://<workgroup>/<database>/<table>` - query an existing AWS Organizations CloudTrail trail via Amazon Athena, instead of CloudTrail Lake. See [Athena audit log configuration]({% link docs/deployment/configuration/athena.md %}) for the one-time table setup this requires.
 - **SECRET_NAME** - Name of the Secret stored in AWS Secret Manager
 > When using Github as the external repository ensure you use Tokens (classic) (https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#personal-access-tokens-classic) instead of Fine-grained tokens
 
@@ -63,6 +67,7 @@ Update the parameters in the **parameters.sh** file as follows:
 - **TAGS** - Tags that should be propagated to nested stacks and underlying resources
 - **UI_DOMAIN** - Custom domain for Amplify hosted frontend application (should only be included if you have setup a custom domain for the frontend application)
 - **CACHE_TTL** - Cache time-to-live in seconds for organizational unit (OU) account lists (default: 604800 = 1 week). Cached entries automatically expire after this duration. Consider increasing this value (e.g., 2592000 = 30 days) for organizations with infrequent account changes. Administrators can also manually invalidate specific OU cache entries or disable caching entirely via the Settings page.
+- **ATHENA_TRAIL_BUCKET_ARN**, **ATHENA_RESULTS_BUCKET_ARN**, **ATHENA_TRAIL_KMS_KEY_ARN** - Required only when **CLOUDTRAIL_AUDIT_LOGS** is an `athena://` URI. See [Athena audit log configuration]({% link docs/deployment/configuration/athena.md %}).
 
 For example:
 

--- a/docs/docs/deployment/prerequisites.md
+++ b/docs/docs/deployment/prerequisites.md
@@ -33,9 +33,15 @@ parent: Solution deployment
   [As per AWS best practice](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_best-practices_mgmt-acct.html#best-practices_mgmt-use), it is not recommended to deploy resources in the organization management account. Designate a dedicated account for deploying the TEAM solution. We recommend that you do not deploy any other workloads in this account, and carefully manage users with access to this account based on a need-to-do principle.
   {: .note}
 
-### Cloudtrail Lake organization event datastore
-TEAM uses AWS CloudTrail Lake for querying, auditing and logging API activities and actions performed by a user during the period of elevated access.
-Create a Cloudtrail Lake organization event datastore in the dedicated TEAM account that stores all log events for all AWS account in your organization
+### Audit log backend
+TEAM queries an audit log backend to show which API calls a user made during a period of elevated access. You can choose between two backends:
+
+- **CloudTrail Lake** - Create a Cloudtrail Lake organization event datastore in the dedicated TEAM account that stores all log events for all AWS account in your organization.
+
+  > AWS closed CloudTrail Lake to new customers on May 31, 2026. Existing CloudTrail Lake customers can continue using it, but `CreateEventDataStore` now fails for accounts that never had a Lake event data store before. New adopters must use the Athena backend, or set `CloudTrailAuditLogs=none` to deploy without audit log querying.
+  {: .important}
+
+- **Amazon Athena** - Query an existing AWS Organizations CloudTrail trail already delivering logs to S3, via Athena. See [Athena audit log configuration]({% link docs/deployment/configuration/athena.md %}) for the one-time setup required before deployment.
 
 ## AWS Secrets Manager
 TEAM allows you to use external repositories for deploying the solution. 

--- a/docs/docs/overview/cost.md
+++ b/docs/docs/overview/cost.md
@@ -16,7 +16,7 @@ The TEAM solution consists of numerous AWS serverless services. As cost is accru
 - [AWS Lambda](https://aws.amazon.com/lambda/pricing)
 - [AWS Step Functions](https://aws.amazon.com/step-functions/pricing)
 - [Amazon Cognito](https://aws.amazon.com/cognito/pricing)
-- [AWS CloudTrail Lake](https://aws.amazon.com/cloudtrail/pricing/)
+- [AWS CloudTrail Lake](https://aws.amazon.com/cloudtrail/pricing/) or [Amazon Athena](https://aws.amazon.com/athena/pricing/), depending on which audit log backend you configure
 - [AWS IAM Identity Center](https://aws.amazon.com/iam/identity-center/) (free)
 - [AWS Secret Manager](https://aws.amazon.com/secrets-manager/)
 
@@ -25,3 +25,7 @@ The TEAM solution consists of numerous AWS serverless services. As cost is accru
 TEAM uses [AWS CloudTrail Lake](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-lake.html) for querying, auditing and logging API activities and actions performed by a user during the period of elevated access. For CloudTrail Lake, you pay for ingestion and storage together, where the billing is based on the amount of uncompressed data ingested during the month. When you run queries in Lake, you pay based upon the amount of data scanned. 
 
 TEAM CloudTrail lake event datastore records all [management events](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-management-events-with-cloudtrail.html) and no [data events](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-data-events-with-cloudtrail.html) by default. Depending on your organization's auditing and compliance requirement, you can chose to either log all events or specific events (read-only, write, read-write, management, data events). Recording only specific events can help to reduce the overall cost of running the TEAM solution. For more information about managing CloudTrail lake costs, see [Managing CloudTrail Lake costs](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-lake-manage-costs.html).
+
+## Managing Athena audit log cost
+
+If you configure TEAM to query an existing CloudTrail trail via Amazon Athena (see [Athena audit log configuration]({% link docs/deployment/configuration/athena.md %})), you pay per query based on the amount of data scanned, rather than for ingestion and storage. Partition projection - configured once, in the Glue table you create - is what keeps each session lookup scoped to megabytes rather than your organization's entire trail history; verify it is working before relying on this backend in production.

--- a/parameters.js
+++ b/parameters.js
@@ -6,7 +6,7 @@
 const fs = require("fs");
 const path = require("path");
 
-const { AWS_APP_ID, AWS_BRANCH, SSO_LOGIN, TEAM_ADMIN_GROUP, TEAM_AUDITOR_GROUP, TAGS, CLOUDTRAIL_AUDIT_LOGS, TEAM_ACCOUNT, AMPLIFY_CUSTOM_DOMAIN } = process.env;
+const { AWS_APP_ID, AWS_BRANCH, SSO_LOGIN, TEAM_ADMIN_GROUP, TEAM_AUDITOR_GROUP, TAGS, CLOUDTRAIL_AUDIT_LOGS, TEAM_ACCOUNT, AMPLIFY_CUSTOM_DOMAIN, ATHENA_TRAIL_BUCKET_ARN, ATHENA_RESULTS_BUCKET_ARN, ATHENA_TRAIL_KMS_KEY_ARN } = process.env;
 
 async function update_auth_parameters() {
   console.log(`updating amplify config for branch "${AWS_BRANCH}"...`);
@@ -150,9 +150,29 @@ async function update_cloudtrail_parameters() {
   );
 }
 
+async function update_athena_parameters() {
+  console.log(`updating teamgetLogs/teamqueryLogs Athena IAM-scoping parameters"...`);
+
+  for (const functionName of ["teamgetLogs", "teamqueryLogs"]) {
+    const parametersJsonPath = path.resolve(
+      `./amplify/backend/function/${functionName}/parameters.json`
+    );
+
+    fs.writeFileSync(
+      parametersJsonPath,
+      JSON.stringify({
+        AthenaTrailBucketArn: ATHENA_TRAIL_BUCKET_ARN || "",
+        AthenaResultsBucketArn: ATHENA_RESULTS_BUCKET_ARN || "",
+        AthenaTrailKmsKeyArn: ATHENA_TRAIL_KMS_KEY_ARN || "",
+      }, null, 4)
+    );
+  }
+}
+
 update_auth_parameters();
 update_react_parameters();
 update_groups_parameters();
 update_router_parameters()
 update_tag_parameters();
 update_cloudtrail_parameters();
+update_athena_parameters();


### PR DESCRIPTION
*Issue #511 , if available:*

## Summary

AWS closed CloudTrail Lake to new customers on **2026-05-31**. `CreateEventDataStore` now fails for any account that never had a Lake event data store before, which makes TEAM undeployable for new adopters (#511). This PR adds **Amazon Athena** as an alternative audit-log backend — querying an existing AWS Organizations CloudTrail trail already delivered to S3 — selectable via the existing `CloudTrailAuditLogs` parameter.

Existing CloudTrail Lake deployments are unaffected. This also fixes `CloudTrailAuditLogs=none`, which currently still creates a (now-failing) event data store.

## What changed

- **New backend value**: `CloudTrailAuditLogs=athena://<workgroup>/<database>/<table>`. TEAM does not create the Glue table, crawler, or workgroup — you point it at one you already manage.
- **`none` bug fix**: removed `none` from the `CreateEventDataStore` `Fn::Or`, so setting `none` no longer creates an event data store at all.
- **Lambda dispatch**: `teamgetLogs` (DynamoDB-stream triggered, starts + polls the query) and `teamqueryLogs` (AppSync resolver, fetches results) both dispatch on the `EVENT_DATA_STORE` env var prefix — `athena://` → Athena, `none` → skip/empty result, anything else → the existing CloudTrail Lake path, byte-for-byte unchanged.
- **Result normalization**: the Athena path strips the header row `GetQueryResults` includes on its first page and aliases columns (`eventID`, `eventName`, `eventSource`, `eventTime`) to exactly match what the `Logs` GraphQL type and frontend already expect — no schema or UI changes.
- **IAM, least-privilege, zero-diff for existing installs**: new IAM statements are gated behind a `IsAthenaEnabled` condition that only evaluates true when a new optional `AthenaTrailBucketArn` parameter is set. Workgroup/database/table are parsed out of the existing `athena://...` value via `Fn::Select`/`Fn::Split` — no new selector parameters needed for those. Only three new optional deployment parameters were added (`AthenaTrailBucketArn`, `AthenaResultsBucketArn`, `AthenaTrailKmsKeyArn`), used purely to scope S3/KMS ARNs — never `Resource: "*"`. Permissions are split least-privilege across the two Lambdas (`teamgetLogs` gets `StartQueryExecution`/`GetQueryExecution` + trail bucket; `teamqueryLogs` gets only `GetQueryResults` + results bucket).
- **Docs**: new [Athena audit log configuration](docs/docs/deployment/configuration/athena.md) page with the one-time `CREATE EXTERNAL TABLE` DDL (partition projection on account/region/date), cross-account bucket policy, and a cost note; updated prerequisites, deployment parameters, and cost docs to mention the Lake closure and the new backend.

## Backward compatibility

Deployments running `update.sh`/`deploy.sh` with an unchanged `parameters.sh` get identical behavior:
- `CloudTrailAuditLogs` = `read`/`write`/`read_write`/an event data store ARN → same event data store creation/reuse as before.
- The three new Athena parameters default to `""`, so `IsAthenaEnabled` is always false and CloudFormation skips those IAM resources entirely — no new IAM statements are added to any existing deployment.

## Out of scope

- Removing/deprecating the CloudTrail Lake path
- Any change under `src/` (frontend) — none was needed; the Athena path returns the same shape/field names as Lake
- CloudWatch Logs Insights as a third backend
- Migrating existing Lake data
- Creating the Glue table, crawler, or Athena workgroup (documented as a one-time user setup step)

## Test plan

- [x] JSON/YAML template validity checked locally (no live AWS credentials available in this environment to run `cloudformation validate-template`)
- [x] Manually walked `CreateEventDataStore`/`IsReadOnlyEnabled`/`IsReadAndWriteEnabled`/`IsAuditLogsDisabled`/`EventDataStoreOutput` evaluation for all 4 existing value shapes + the new `athena://` shape
- [x] Dry-ran the Lambda dispatch logic (prefix detection + `EventDataStore` derivation) for all 4 value shapes
- [x] Confirmed `IsAthenaEnabled` evaluates false (no new IAM statements) whenever the new Athena parameters are left at their defaults
- [x] End-to-end deploy against a real organization trail + Athena workgroup (not done in this environment)

Refs #511

