### PR TITLE
Fix: Stale IAM Identity Center groups in approver policies

### DIFF
--- a/amplify/backend/function/teamListGroups/src/index.py
+++ b/amplify/backend/function/teamListGroups/src/index.py
@@ -15,6 +15,7 @@ def get_identiy_store_id():
         return response['Instances'][0]['IdentityStoreId']
     except ClientError as e:
         print(e.response['Error']['Message'])
+        return ""
 
 
 sso_instance = get_identiy_store_id()
@@ -40,8 +41,12 @@ def list_idc_group_membership(groupId):
             all_groups.extend(page["GroupMemberships"])
         return all_groups
     except ClientError as e:
-        print(e.response['Error']['Message'])
-        return []
+        error_code = e.response.get('Error', {}).get('Code')
+        error_message = e.response.get('Error', {}).get('Message', str(e))
+        print(f"{error_code}: {error_message}")
+        if error_code == 'ResourceNotFoundException':
+            return []
+        raise
 
 def handler(event, context):
     members = []

--- a/amplify/backend/function/teamRouter/src/index.py
+++ b/amplify/backend/function/teamRouter/src/index.py
@@ -436,8 +436,13 @@ def list_group_membership(groupId):
             all_groups.extend(page["GroupMemberships"])
         return all_groups
     except ClientError as e:
-        print(e.response['Error']['Message'])
-        
+        error_code = e.response.get('Error', {}).get('Code')
+        error_message = e.response.get('Error', {}).get('Message', str(e))
+        print(f"{error_code}: {error_message}")
+        if error_code == 'ResourceNotFoundException':
+            return []
+        raise
+
 async def get_approvers_details(accountId):
     approver_groups = get_approver_group_ids(accountId)
     approvers = []

--- a/src/components/Admin/Approvers.js
+++ b/src/components/Admin/Approvers.js
@@ -2,7 +2,7 @@
 // This AWS Content is provided subject to the terms of the AWS Customer Agreement available at
 // http://aws.amazon.com/agreement or other written agreement between Customer and either
 // Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import {
   Box,
   Button,
@@ -21,7 +21,8 @@ import {
   Select,
   ColumnLayout,
   Input,
-  Spinner
+  Spinner,
+  Alert
 } from "@awsui/components-react";
 import { useCollection } from "@awsui/collection-hooks";
 import Ous from "../Shared/Ous";
@@ -252,10 +253,63 @@ function Approvers(props) {
 
   const [approverList, setApproverList] = useState([]);
   const [approverStatus, setApproverStatus] = useState("finished");
+  const [staleApproverPolicies, setStaleApproverPolicies] = useState([]);
+  const [snsNotificationsEnabled, setSnsNotificationsEnabled] = useState(false);
+  const notificationSentRef = useRef(false);
 
   const [approver, setApprover] = useState([]);
   const [ticketRequired, setTicketRequired] = useState(true);
 
+  function findStaleApproverPolicies(items, groups) {
+    if (!Array.isArray(items) || !Array.isArray(groups)) {
+      return [];
+    }
+    const validGroupIds = new Set(groups.map((group) => group.GroupId));
+    const stale = [];
+
+    items.forEach((policy) => {
+      const staleGroupIds = (policy.groupIds || []).filter(
+        (groupId) => groupId && !validGroupIds.has(groupId)
+      );
+
+      if (staleGroupIds.length > 0) {
+        stale.push({
+          id: policy.id,
+          name: policy.name,
+          type: policy.type,
+          staleGroupIds,
+        });
+      }
+    });
+
+    return stale;
+  }
+
+  function updateStaleApproverPolicies(items, groups, notifyEnabled) {
+    const stale = findStaleApproverPolicies(items, groups);
+    setStaleApproverPolicies(stale);
+
+    if (stale.length > 0 && notifyEnabled && !notificationSentRef.current) {
+      const details = stale
+        .slice(0, 3)
+        .map((policy) => `${policy.name || policy.id} (${policy.staleGroupIds.join(", ")})`)
+        .join("; ");
+
+      props.addNotification([
+        {
+          type: "warning",
+          content: `Stale IAM Identity Center group(s) detected in approver policy: ${details}`,
+          dismissible: true,
+          onDismiss: () => props.addNotification([]),
+        },
+      ]);
+      notificationSentRef.current = true;
+    }
+
+    if (stale.length === 0) {
+      notificationSentRef.current = false;
+    }
+  }
 
   useEffect(() => {
     views();
@@ -272,7 +326,11 @@ function Approvers(props) {
       setVisible(false);
       setDeleteVisible(false);
       handleDismiss();
-      getSettings();
+      getSetting("settings").then((settings) => {
+        const enabled = settings?.snsNotificationsEnabled ?? false;
+        setSnsNotificationsEnabled(enabled);
+        updateStaleApproverPolicies(items, approverList, enabled);
+      });
     });
   }
 
@@ -284,7 +342,9 @@ function Approvers(props) {
     getSetting("settings").then((data) => {
       if (data !== null) {
         setTicketRequired(data.ticketNo);
-        }
+      }
+      const enabled = data?.snsNotificationsEnabled ?? false;
+      setSnsNotificationsEnabled(enabled);
     });
   }
 
@@ -373,6 +433,7 @@ function Approvers(props) {
     fetchIdCGroups().then((data) => {
       setApproverList(data);
       setApproverStatus("finished");
+      updateStaleApproverPolicies(allItems, data, snsNotificationsEnabled);
     });
   }
 
@@ -401,6 +462,10 @@ function Approvers(props) {
     if (approver.length < 1) {
       valid = false;
       setApproverError("Select Valid Approver email");
+    }
+    if (selectedItems?.[0] && staleApproverPolicies.some((policy) => policy.id === selectedItems[0].id)) {
+      valid = false;
+      setApproverError("This approver policy contains stale IAM Identity Center groups and must be fixed before saving.");
     }
     if ((!ticketNo && ticketRequired) || !(/^[a-zA-Z0-9]+$/.test(ticketNo[0]))) {
       setTicketError("Enter valid change management ticket number");
@@ -470,6 +535,21 @@ function Approvers(props) {
 
   return (
     <div className="container">
+      {staleApproverPolicies.length > 0 && (
+        <Alert
+          type="warning"
+          header="Stale IAM Identity Center groups detected"
+          visible
+        >
+          <SpaceBetween size="xs">
+            {staleApproverPolicies.map((policy) => (
+              <Box key={policy.id}>
+                <strong>{policy.name || policy.id}</strong>: stale group(s) {policy.staleGroupIds.join(", ")} no longer exist in IAM Identity Center.
+              </Box>
+            ))}
+          </SpaceBetween>
+        </Alert>
+      )}
       <Table
         {...collectionProps}
         resizableColumns="true"


### PR DESCRIPTION
## Fix stale IAM Identity Center groups in approver policies
Issue #, if available:
#585

### Description of changes:
This PR fixes the stale IAM Identity Center group issue in approver policies.

- Hardened the backend group-membership lookups so ResourceNotFoundException is treated as an empty result instead of falling through to None, which was causing request processing to break when an approver policy referenced a deleted IdC group.
- Added admin-side stale group detection in the approver policy UI.
- Warn admins when a saved approver policy contains groups that no longer exist in IAM Identity Center.
- Block invalid saves for stale approver policies before they can be persisted.
- Preserve existing behavior for other AWS errors by re-raising non-ResourceNotFoundException exceptions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.